### PR TITLE
fixed overture schema reference link to open in new tab

### DIFF
--- a/site/src/InspectorPanel.jsx
+++ b/site/src/InspectorPanel.jsx
@@ -23,7 +23,7 @@ function InspectorPanel({ entity }) {
         </tbody>
       </table>
       <p>
-        <a href="https://docs.overturemaps.org/schema/">
+        <a href="https://docs.overturemaps.org/schema/" target="_blank" rel="noreferrer noopener">
           Overture Schema Reference
         </a>
       </p>


### PR DESCRIPTION
Previously, clicking the overture schema reference link opened in the current tab. Now, it will open in a new tab