### PR TITLE
Fix CSS height of MapLibre element to show attribution [#41]

### DIFF
--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -113,7 +113,7 @@ export default function Map({mode}) {
           interactiveLayerIds={interactiveLayerIds}
           initialViewState={INITIAL_VIEW_STATE}
           mapStyle={getMapStyle()}
-          style={{position: 'fixed', width: '100%', height: '100%'}}
+          style={{position: 'fixed', width: '100%', height: 'calc(100vh - 60px)'}}
         >
           <Source id="overture-places" type="vector" url={PLACES_PMTILES_URL}>
             <Layer {...PLACES_MAP_STYLE} layout={{visibility: interactiveLayerIds.includes('places') ? 'visible' : 'none'}} />


### PR DESCRIPTION
Shortens the map by 60px (the navbar height)

<img width="721" alt="Screenshot 2024-05-25 at 16 10 52" src="https://github.com/OvertureMaps/io-site/assets/77501/e4c21e33-de45-4a19-af38-3ced52109f4b">
