### PR TITLE
Add May Places, Divisions and Buildings themes. [#25, #41]

### DIFF
--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -1,129 +1,232 @@
-import { Map as MapLibreMap, NavigationControl, Source } from 'react-map-gl/maplibre';
-import 'maplibre-gl/dist/maplibre-gl.css';
-import * as pmtiles from 'pmtiles';
-import maplibregl from 'maplibre-gl';
-import { useState, useEffect, useCallback } from 'react';
-import { Layer, GeolocateControl } from 'react-map-gl/maplibre';
- import InspectorPanel from './InspectorPanel';
-import PropTypes from 'prop-types';
-import './InspectorPanel.css';
-import './CustomControls.css';
-import ThemeSelector from './ThemeSelector';
+import {
+  Map as MapLibreMap,
+  NavigationControl,
+  Source,
+  AttributionControl,
+} from "react-map-gl/maplibre";
+import "maplibre-gl/dist/maplibre-gl.css";
+import * as pmtiles from "pmtiles";
+import maplibregl from "maplibre-gl";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Layer, GeolocateControl } from "react-map-gl/maplibre";
+import InspectorPanel from "./InspectorPanel";
+import PropTypes from "prop-types";
+import "./InspectorPanel.css";
+import "./CustomControls.css";
+import ThemeSelector from "./ThemeSelector";
 
-const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
-const DARK_MAP_STYLE = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json'
-
-const PLACES_PMTILES_URL = 'pmtiles://https://data.source.coop/protomaps/overture/2024-04-16-beta.0/places.pmtiles';
-const PLACES_MAP_STYLE = {
-  'id': 'places',
-  'type': 'circle',
-  'source': 'places',
-  'source-layer': 'places',
-  'filter': [">=", ["get", "confidence"], 0.0],
-  'paint': {
-    'circle-color':
-      ['case',
-        ['==', ['get', '@category'], 'beauty_salon'], '#fb9a99',
-        ['==', ['get', '@category'], 'hotel'], '#33a02c',
-        ['==', ['get', '@category'], 'landmark_and_historical_building'], '#a6cee3',
-        ['==', ['get', '@category'], 'professional_services'], '#fdbf6f',
-        ['==', ['get', '@category'], 'shopping'], '#e31a1c',
-        ['==', ['get', '@category'], 'restaurant'], '#1f78b4',
-        ['==', ['get', '@category'], 'school'], '#ff7f00',
-        ['==', ['get', '@category'], 'accommodation'], '#b2df8a',
-        '#cab2d6'
-      ],
-    'circle-radius': [
-      'interpolate',
-      ['exponential', 2],
-      ['zoom'],
-      0, 1,
-      19, 8
-    ],
-    'circle-stroke-width': [
-      'interpolate',
-      ['exponential', 2],
-      ['zoom'],
-      12, 0,
-      14, 2
-    ],
-    'circle-stroke-color': 'black'
-  }
-};
-
+const PMTILES_URL =
+  "pmtiles://https://data.source.coop/protomaps/overture/2024-05-16-beta.0/";
 
 const INITIAL_VIEW_STATE = {
-  latitude: 51.0500,
+  latitude: 51.05,
   longitude: 3.7303,
   zoom: 16,
   bearing: 0,
-  pitch: 0
+  pitch: 0,
 };
-export default function Map({mode}) {
 
-  const [pmTilesReady, setPmTilesReady] = useState(false)
-  const [cursor, setCursor] = useState('auto');
+// this reference must remain constant to avoid re-renders
+const MAP_STYLE = {
+  version: 8,
+  glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
+  sources: {},
+  layers: [],
+};
+
+const ThemeSource = ({ name, url }) => {
+  return <Source id={name} type="vector" url={`${url}${name}.pmtiles`} />;
+};
+
+ThemeSource.propTypes = {
+  name: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+};
+
+const ThemeTypeLayer = ({ theme, type, color, point, line, polygon }) => {
+  return (
+    <>
+      {point ? (
+        <Layer
+          beforeId="divisions_division"
+          id={`${theme}_${type}_point`}
+          type="circle"
+          source={theme}
+          source-layer={type}
+          paint={{
+            "circle-color": color,
+            "circle-radius": [
+              "interpolate",
+              ["exponential", 2],
+              ["zoom"],
+              0,
+              1,
+              17,
+              8,
+            ],
+          }}
+        />
+      ) : null}
+      {line ? (
+        <Layer
+          beforeId="divisions_division"
+          id={`${theme}_${type}_line`}
+          type="line"
+          source={theme}
+          source-layer={type}
+          paint={{ "line-color": color }}
+        />
+      ) : null}
+      {polygon ? (
+        <Layer
+          beforeId="divisions_division"
+          id={`${theme}_${type}_fill`}
+          type="fill"
+          source={theme}
+          source-layer={type}
+          paint={{ "fill-color": color, "fill-opacity": 0.25 }}
+        />
+      ) : null}
+    </>
+  );
+};
+
+ThemeTypeLayer.propTypes = {
+  theme: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired,
+  point: PropTypes.bool,
+  line: PropTypes.bool,
+  polygon: PropTypes.bool,
+};
+
+export default function Map({ mode }) {
+  const mapRef = useRef();
+  const [cursor, setCursor] = useState("auto");
   const [mapEntity, setMapEntity] = useState({});
 
+  const [visibleThemes, setVisibleThemes] = useState([]);
+  const [interactiveLayerIds, setInteractiveLayerIds] = useState([]);
+
   useEffect(() => {
-    const protocol = new pmtiles.Protocol()
-    maplibregl.addProtocol('pmtiles', protocol.tile)
-    setPmTilesReady(true)
+    const protocol = new pmtiles.Protocol();
+    maplibregl.addProtocol("pmtiles", protocol.tile);
+    return () => {
+      maplibregl.removeProtocol("pmtiles");
+    };
   }, []);
 
-  const [interactiveLayerIds, setInteractiveLayerIds] = useState(['places']);
-  // const onInteractiveLayersChange = useCallback(layerFilter => {
-  //   setInteractiveLayerIds(MAP_STYLE.layers.map(layer => layer.id).filter(layerFilter));
-  // }, []);
+  const syncInteractiveLayerIds = useCallback(() => {
+    const layers = mapRef.current.getStyle().layers;
+    const layersToShow = layers
+      .filter((layer) => visibleThemes.indexOf(layer.source) >= 0)
+      .map((layer) => layer.id);
+    setInteractiveLayerIds(layersToShow);
+  }, [visibleThemes]);
 
-  const onMouseEnter = useCallback(() => setCursor('pointer'), []);
-  const onMouseLeave = useCallback(() => setCursor('auto'), []);
+  const onMouseEnter = useCallback(() => setCursor("pointer"), []);
+  const onMouseLeave = useCallback(() => setCursor("auto"), []);
 
-  const onClick = useCallback(event => {
+  const onClick = useCallback((event) => {
     const feature = event.features && event.features[0];
-
     if (feature) {
-      setMapEntity(event.features[0].properties);
+      setMapEntity({
+        theme: feature.source,
+        type: feature.sourceLayer,
+        ...feature.properties,
+      });
     } else {
       setMapEntity({});
     }
   }, []);
 
-  function getMapStyle() {
-    let mapStyle;
-
-    if (pmTilesReady){
-     mapStyle =  mode === 'theme-light' ? MAP_STYLE : DARK_MAP_STYLE;
-    } else {
-      mapStyle = undefined;
-    }
-    return mapStyle;
-  }
-
   return (
     <>
       <div className={`map ${mode}`}>
         <MapLibreMap
-          id="myMap"
+          ref={mapRef}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
+          onLoad={syncInteractiveLayerIds}
           onClick={onClick}
           cursor={cursor}
           hash={true}
+          mapStyle={MAP_STYLE}
           interactiveLayerIds={interactiveLayerIds}
           initialViewState={INITIAL_VIEW_STATE}
-          mapStyle={getMapStyle()}
-          style={{position: 'fixed', width: '100%', height: 'calc(100vh - 60px)'}}
+          style={{
+            position: "fixed",
+            width: "100%",
+            height: "calc(100vh - 60px)",
+          }}
+          attributionControl={false}
         >
-          <Source id="overture-places" type="vector" url={PLACES_PMTILES_URL}>
-            <Layer {...PLACES_MAP_STYLE} layout={{visibility: interactiveLayerIds.includes('places') ? 'visible' : 'none'}} />
-          </Source>
-          <NavigationControl position='top-right'></NavigationControl>
+          <ThemeSource name="buildings" url={PMTILES_URL} />
+          <ThemeSource name="places" url={PMTILES_URL} />
+          <ThemeSource name="divisions" url={PMTILES_URL} />
+
+          <Layer
+            id="divisions_division"
+            type="symbol"
+            source="divisions"
+            source-layer="division"
+            paint={{
+              "text-color": mode === "theme-light" ? "black" : "white",
+              "text-halo-color": mode === "theme-light" ? "white" : "black",
+              "text-halo-width": 1,
+            }}
+            layout={{
+              "text-font": ["Noto Sans Regular"],
+              "text-field": ["get", "@name"],
+              "text-size": 11,
+            }}
+          />
+
+          {visibleThemes.includes("divisions") ? (
+            <>
+              <ThemeTypeLayer
+                theme="divisions"
+                type="division_area"
+                polygon
+                color="#bc80bd"
+              />
+              <ThemeTypeLayer
+                theme="divisions"
+                type="boundary"
+                line
+                color="#bc80bd"
+              />
+            </>
+          ) : null}
+          {visibleThemes.includes("buildings") ? (
+            <>
+              <ThemeTypeLayer
+                theme="buildings"
+                type="building"
+                polygon
+                color="#d9d9d9"
+              />
+              <ThemeTypeLayer
+                theme="buildings"
+                type="building_part"
+                polygon
+                color="#d9d9d9"
+              />
+            </>
+          ) : null}
+          {visibleThemes.includes("places") ? (
+            <ThemeTypeLayer theme="places" type="place" point color="#fdb462" />
+          ) : null}
+
+          <NavigationControl position="top-right"></NavigationControl>
           <GeolocateControl />
+          <AttributionControl customAttribution='<a href="https://openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>, <a href="https://overturemaps.org" target="_blank">Overture Maps Foundation</a>' />
         </MapLibreMap>
         <div className="custom-controls">
-          {Object.keys(mapEntity).length > 0 && <InspectorPanel entity={mapEntity} />}
-          <ThemeSelector interactiveLayers={setInteractiveLayerIds}></ThemeSelector>
+          {Object.keys(mapEntity).length > 0 && (
+            <InspectorPanel entity={mapEntity} />
+          )}
+          <ThemeSelector visibleThemes={setVisibleThemes}></ThemeSelector>
         </div>
       </div>
     </>
@@ -131,5 +234,5 @@ export default function Map({mode}) {
 }
 
 Map.propTypes = {
-  mode: PropTypes.string.isRequired
-}
+  mode: PropTypes.string.isRequired,
+};

--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -51,13 +51,13 @@ const ThemeTypeLayer = ({
   line,
   polygon,
   extrusion,
+  visible,
 }) => {
   return (
     <>
       {point ? (
         <Layer
           filter={["==", ["geometry-type"], "Point"]}
-          beforeId="divisions_division"
           id={`${theme}_${type}_point`}
           type="circle"
           source={theme}
@@ -74,28 +74,29 @@ const ThemeTypeLayer = ({
               8,
             ],
           }}
+          layout={{ visibility: visible ? "visible" : "none" }}
         />
       ) : null}
       {line ? (
         <Layer
           filter={["==", ["geometry-type"], "LineString"]}
-          beforeId="divisions_division"
           id={`${theme}_${type}_line`}
           type="line"
           source={theme}
           source-layer={type}
           paint={{ "line-color": color }}
+          layout={{ visibility: visible ? "visible" : "none" }}
         />
       ) : null}
       {polygon ? (
         <Layer
           filter={["==", ["geometry-type"], "Polygon"]}
-          beforeId="divisions_division"
           id={`${theme}_${type}_fill`}
           type="fill"
           source={theme}
           source-layer={type}
           paint={{ "fill-color": color, "fill-opacity": 0.2 }}
+          layout={{ visibility: visible ? "visible" : "none" }}
         />
       ) : null}
       {extrusion ? (
@@ -105,7 +106,6 @@ const ThemeTypeLayer = ({
             ["==", ["geometry-type"], "Polygon"],
             ["!=", ["get", "has_parts"], true],
           ]} // prevent z-fighting
-          beforeId="divisions_division"
           id={`${theme}_${type}_fill-extrusion`}
           type="fill-extrusion"
           source={theme}
@@ -116,6 +116,7 @@ const ThemeTypeLayer = ({
             "fill-extrusion-base": ["get", "min_height"],
             "fill-extrusion-height": ["get", "height"],
           }}
+          layout={{ visibility: visible ? "visible" : "none" }}
         />
       ) : null}
     </>
@@ -197,7 +198,100 @@ export default function Map({ mode }) {
           <ThemeSource name="buildings" url={PMTILES_URL} />
           <ThemeSource name="places" url={PMTILES_URL} />
           <ThemeSource name="divisions" url={PMTILES_URL} />
+          <ThemeSource name="transportation" url={PMTILES_URL} />
 
+          <ThemeTypeLayer
+            theme="base"
+            type="land"
+            point
+            line
+            polygon
+            color="#ccebc5"
+            visible={visibleThemes.includes("base")}
+          />
+          <ThemeTypeLayer
+            theme="base"
+            type="land_cover"
+            polygon
+            color="#b3de69"
+            visible={visibleThemes.includes("base")}
+          />
+          <ThemeTypeLayer
+            theme="base"
+            type="land_use"
+            point
+            line
+            polygon
+            color="#b3de69"
+            visible={visibleThemes.includes("base")}
+          />
+          <ThemeTypeLayer
+            theme="base"
+            type="water"
+            point
+            line
+            polygon
+            color="#80b1d3"
+            visible={visibleThemes.includes("base")}
+          />
+          <ThemeTypeLayer
+            theme="base"
+            type="infrastructure"
+            point
+            line
+            polygon
+            color="#b3de69"
+            visible={visibleThemes.includes("base")}
+          />
+          <ThemeTypeLayer
+            theme="divisions"
+            type="division_area"
+            polygon
+            color="#bc80bd"
+            visible={visibleThemes.includes("divisions")}
+          />
+          <ThemeTypeLayer
+            theme="divisions"
+            type="boundary"
+            line
+            color="#bc80bd"
+            visible={visibleThemes.includes("divisions")}
+          />
+          <ThemeTypeLayer
+            theme="transportation"
+            type="segment"
+            line
+            color="#fb8072"
+            visible={visibleThemes.includes("transportation")}
+          />
+          <ThemeTypeLayer
+            theme="transportation"
+            type="connector"
+            point
+            color="#fb8072"
+            visible={visibleThemes.includes("transportation")}
+          />
+          <ThemeTypeLayer
+            theme="buildings"
+            type="building"
+            extrusion
+            color="#d9d9d9"
+            visible={visibleThemes.includes("buildings")}
+          />
+          <ThemeTypeLayer
+            theme="buildings"
+            type="building_part"
+            extrusion
+            color="#d9d9d9"
+            visible={visibleThemes.includes("buildings")}
+          />
+          <ThemeTypeLayer
+            theme="places"
+            type="place"
+            point
+            color="#fdb462"
+            visible={visibleThemes.includes("places")}
+          />
           <Layer
             id="divisions_division"
             type="symbol"
@@ -214,84 +308,6 @@ export default function Map({ mode }) {
               "text-size": 11,
             }}
           />
-
-          {visibleThemes.includes("base") ? (
-            <>
-              <ThemeTypeLayer
-                theme="base"
-                type="land"
-                point
-                line
-                polygon
-                color="#ccebc5"
-              />
-              <ThemeTypeLayer
-                theme="base"
-                type="land_cover"
-                polygon
-                color="#b3de69"
-              />
-              <ThemeTypeLayer
-                theme="base"
-                type="land_use"
-                point
-                line
-                polygon
-                color="#b3de69"
-              />
-              <ThemeTypeLayer
-                theme="base"
-                type="water"
-                point
-                line
-                polygon
-                color="#80b1d3"
-              />
-              <ThemeTypeLayer
-                theme="base"
-                type="infrastructure"
-                point
-                line
-                polygon
-                color="#b3de69"
-              />
-            </>
-          ) : null}
-          {visibleThemes.includes("divisions") ? (
-            <>
-              <ThemeTypeLayer
-                theme="divisions"
-                type="division_area"
-                polygon
-                color="#bc80bd"
-              />
-              <ThemeTypeLayer
-                theme="divisions"
-                type="boundary"
-                line
-                color="#bc80bd"
-              />
-            </>
-          ) : null}
-          {visibleThemes.includes("buildings") ? (
-            <>
-              <ThemeTypeLayer
-                theme="buildings"
-                type="building"
-                extrusion
-                color="#d9d9d9"
-              />
-              <ThemeTypeLayer
-                theme="buildings"
-                type="building_part"
-                extrusion
-                color="#d9d9d9"
-              />
-            </>
-          ) : null}
-          {visibleThemes.includes("places") ? (
-            <ThemeTypeLayer theme="places" type="place" point color="#fdb462" />
-          ) : null}
 
           <NavigationControl position="top-right"></NavigationControl>
           <GeolocateControl />

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -3,12 +3,11 @@ import { useState, useEffect } from "react";
 import LayerIcon from "./icons/icon-layers.svg?react";
 import "./ThemeSelector.css"; 
 
-function ThemeSelector({ interactiveLayers }) {
+function ThemeSelector({ visibleThemes }) {
 
   const [places, setPlaces] = useState(true);
   const [buildings, setBuildings] = useState(true);
-  const [transportation, setTransportation] = useState(true);
-
+  const [divisions, setDivisions] = useState(true);
   
   useEffect(() => {
 
@@ -16,9 +15,9 @@ function ThemeSelector({ interactiveLayers }) {
 
     if (places) layers.push('places');
     if (buildings) layers.push('buildings');
-    if (transportation) layers.push('transportation');
-    interactiveLayers(layers);
-  }, [buildings, places, transportation, interactiveLayers]);
+    if (divisions) layers.push('divisions');
+    visibleThemes(layers);
+  }, [buildings, places, divisions, visibleThemes]);
 
   return (
     <div className="dropdown dropdown--hoverable theme-selector">
@@ -27,13 +26,13 @@ function ThemeSelector({ interactiveLayers }) {
       </div>
       <ul className="dropdown__menu">
         <li> 
-          <label htmlFor="places" className="dropdown__link" ><input id="places" type="checkbox" checked={places} onClick={() => setPlaces(!places)}/>Places</label>
+          <label htmlFor="places" className="dropdown__link" ><input id="places" type="checkbox" checked={places} onChange={() => setPlaces(!places)}/>Places</label>
         </li>
         <li>
-          <label htmlFor="buildings" className="dropdown__link" ><input id="buildings" type="checkbox" checked={buildings} onClick={() => setBuildings(!buildings)}/>Buildings</label>
+          <label htmlFor="buildings" className="dropdown__link" ><input id="buildings" type="checkbox" checked={buildings} onChange={() => setBuildings(!buildings)}/>Buildings</label>
         </li>
         <li>
-          <label htmlFor="transportation" className="dropdown__link" ><input id="transportation" type="checkbox" checked={transportation} onClick={() => setTransportation(!transportation)}/>Transportation</label>
+          <label htmlFor="divisions" className="dropdown__link" ><input id="divisions" type="checkbox" checked={divisions} onChange={() => setDivisions(!divisions)}/>Divisions</label>
         </li>
       </ul>
     </div>
@@ -41,6 +40,6 @@ function ThemeSelector({ interactiveLayers }) {
 }
 
 ThemeSelector.propTypes = {
-  interactiveLayers: PropTypes.function,
+  visibleThemes: PropTypes.func,
 };
 export default ThemeSelector;

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -5,19 +5,21 @@ import "./ThemeSelector.css";
 
 function ThemeSelector({ visibleThemes }) {
 
-  const [places, setPlaces] = useState(true);
+  const [base, setBase] = useState(true);
   const [buildings, setBuildings] = useState(true);
   const [divisions, setDivisions] = useState(true);
+  const [places, setPlaces] = useState(true);
   
   useEffect(() => {
 
     let layers = [];
 
-    if (places) layers.push('places');
+    if (base) layers.push('base');
     if (buildings) layers.push('buildings');
     if (divisions) layers.push('divisions');
+    if (places) layers.push('places');
     visibleThemes(layers);
-  }, [buildings, places, divisions, visibleThemes]);
+  }, [base, buildings, divisions, places, visibleThemes]);
 
   return (
     <div className="dropdown dropdown--hoverable theme-selector">
@@ -25,14 +27,17 @@ function ThemeSelector({ visibleThemes }) {
         <LayerIcon/>
       </div>
       <ul className="dropdown__menu">
-        <li> 
-          <label htmlFor="places" className="dropdown__link" ><input id="places" type="checkbox" checked={places} onChange={() => setPlaces(!places)}/>Places</label>
+        <li>
+          <label htmlFor="base" className="dropdown__link" ><input id="base" type="checkbox" checked={base} onChange={() => setBase(!base)}/>Base</label>
         </li>
         <li>
           <label htmlFor="buildings" className="dropdown__link" ><input id="buildings" type="checkbox" checked={buildings} onChange={() => setBuildings(!buildings)}/>Buildings</label>
         </li>
         <li>
           <label htmlFor="divisions" className="dropdown__link" ><input id="divisions" type="checkbox" checked={divisions} onChange={() => setDivisions(!divisions)}/>Divisions</label>
+        </li>
+        <li>
+          <label htmlFor="places" className="dropdown__link" ><input id="places" type="checkbox" checked={places} onChange={() => setPlaces(!places)}/>Places</label>
         </li>
       </ul>
     </div>

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -9,6 +9,7 @@ function ThemeSelector({ visibleThemes }) {
   const [buildings, setBuildings] = useState(true);
   const [divisions, setDivisions] = useState(true);
   const [places, setPlaces] = useState(true);
+  const [transportation, setTransportation] = useState(true);
   
   useEffect(() => {
 
@@ -18,8 +19,9 @@ function ThemeSelector({ visibleThemes }) {
     if (buildings) layers.push('buildings');
     if (divisions) layers.push('divisions');
     if (places) layers.push('places');
+    if (transportation) layers.push('transportation');
     visibleThemes(layers);
-  }, [base, buildings, divisions, places, visibleThemes]);
+  }, [base, buildings, divisions, places, transportation, visibleThemes]);
 
   return (
     <div className="dropdown dropdown--hoverable theme-selector">
@@ -38,6 +40,9 @@ function ThemeSelector({ visibleThemes }) {
         </li>
         <li>
           <label htmlFor="places" className="dropdown__link" ><input id="places" type="checkbox" checked={places} onChange={() => setPlaces(!places)}/>Places</label>
+        </li>
+        <li>
+          <label htmlFor="transportation" className="dropdown__link" ><input id="transportation" type="checkbox" checked={transportation} onChange={() => setTransportation(!transportation)}/>Transportation</label>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
* change interactiveLayers state to visibleThemes since a single theme has more than one MapLibre layer (one for each type)
* hook up places, divisions, buildings themes to ThemeSelector
* remove non-Overture basemap
* Add components to encapsulate ThemeSource and ThemeTypeLayer objects - use conventions around layer IDs and URLs
* change color palette to x-ray - one color per theme
* add divisions_division label layer from Divisions theme that's always visible to assist navigation
* add glyphs using MapLibre demo repo on GitHub Pages for label layer
* use non-compact static attribution linking to OpenStreetMap and Overture Maps
* add theme and type to inspector properties

Will add comments inline.

Major thing missing is a data-driven way to determine the types (layers) to build out of a theme. This could change from release from release; for now this is hardcoded to May's. 