### PR TITLE
Fixing some light/dark mode issues lying around the site.

### DIFF
--- a/site/src/InspectorPanel.css
+++ b/site/src/InspectorPanel.css
@@ -1,7 +1,7 @@
 .inspector-panel {
   max-width: 400px;
-  display:flex;
-  flex-direction:column;
+  display: flex;
+  flex-direction: column;
   background-color: rgba(255, 255, 255, 0.9);
   color: black;
   box-shadow: 0 2px 4px white;
@@ -14,8 +14,7 @@
   border-radius: 10px;
   border-color: rgba(15, 15, 15, 0.8);
   max-height: 80vh;
-  overflow-y: scroll;
-  position:relative;
+  position: relative;
 
   p {
     margin: 0;
@@ -29,7 +28,8 @@
     background-color: rgba(255, 255, 255, 0.95);
   }
 
-  table th, table td {
+  table th,
+  table td {
     padding: 0;
   }
 
@@ -61,4 +61,7 @@
 
   box-shadow: 0 2px 4px black;
   color: white;
+
+  scrollbar-color: var(--ifm-color-secondary-darkest)
+    var(--ifm-navbar-background-color);
 }

--- a/site/src/InspectorPanel.jsx
+++ b/site/src/InspectorPanel.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 
-function InspectorPanel({ entity }) {
+function InspectorPanel({ entity, mode }) {
   if (!entity) {
     return;
   }
@@ -23,7 +23,11 @@ function InspectorPanel({ entity }) {
         </tbody>
       </table>
       <p>
-        <a href="https://docs.overturemaps.org/schema/" target="_blank" rel="noreferrer noopener">
+        <a
+          href="https://docs.overturemaps.org/schema/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
           Overture Schema Reference
         </a>
       </p>

--- a/site/src/InspectorPanel.jsx
+++ b/site/src/InspectorPanel.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 
-function InspectorPanel({ entity, mode }) {
+function InspectorPanel({ entity }) {
   if (!entity) {
     return;
   }

--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -135,13 +135,11 @@ ThemeTypeLayer.propTypes = {
 };
 
 export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
-
   const mapRef = useRef();
   const [cursor, setCursor] = useState("auto");
 
   const [visibleThemes, setVisibleThemes] = useState([]);
   const [interactiveLayerIds, setInteractiveLayerIds] = useState([]);
-
 
   useEffect(() => {
     const protocol = new pmtiles.Protocol();
@@ -327,7 +325,10 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
             <InspectorPanel entity={mapEntity} />
           )}
 
-          <ThemeSelector visibleThemes={setVisibleThemes}></ThemeSelector>
+          <ThemeSelector
+            mode={mode}
+            visibleThemes={setVisibleThemes}
+          ></ThemeSelector>
         </div>
       </div>
     </>

--- a/site/src/ThemeSelector.css
+++ b/site/src/ThemeSelector.css
@@ -1,13 +1,13 @@
 .theme-selector {
   max-width: 400px;
   background-color: rgba(255, 255, 255, 0.9);
-  border-radius:5px;
+  border-radius: 5px;
   color: black;
-  font-size:0;
+  font-size: 0;
   outline: none;
-  display:flex;
+  display: flex;
   max-height: 32px;
-  margin-top:3px;
+  margin-top: 3px;
 }
 
 .theme-dark .inspector-panel {
@@ -16,14 +16,14 @@
 }
 
 div.layer-control {
-  width:32px;
-  height:32px;
+  width: 32px;
+  height: 32px;
   justify-content: center;
   display: flex;
 }
 img.layer-control {
-  background: white; 
-  width:24px;
+  background: white;
+  width: 24px;
   justify-content: center;
 }
 
@@ -33,4 +33,9 @@ svg.icon-layers > path.primary {
 
 svg.icon-layers > path.secondary {
   fill: cornflowerblue;
+}
+
+svg.icon-layers-dark {
+  background: var(--ifm-navbar-background-color);
+  border-radius: 5px;
 }

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import LayerIcon from "./icons/icon-layers.svg?react";
 import "./ThemeSelector.css";
 
-function ThemeSelector({ visibleThemes }) {
+function ThemeSelector({ visibleThemes, mode }) {
   const [base, setBase] = useState(true);
   const [buildings, setBuildings] = useState(true);
   const [divisions, setDivisions] = useState(true);
@@ -24,7 +24,11 @@ function ThemeSelector({ visibleThemes }) {
   return (
     <div className="dropdown dropdown--hoverable theme-selector tour-layers">
       <div className="layer-control">
-        <LayerIcon />
+        <LayerIcon
+          className={`icon-layers ${
+            mode === "theme-dark" ? "icon-layers-dark" : ""
+          }`}
+        />
       </div>
       <ul className="dropdown__menu">
         <li>

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -92,3 +92,9 @@ div.theme-light {
   color: #213547;
   background-color: #ffffff;
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #ffffff;
+  }
+}


### PR DESCRIPTION
- Added a variable background color for the theme selector icon to match the navbar color scheme in dark mode.
- Changed the gutter color and scroller color for the scroll bar in the inspector panel table during dark mode usage.
- Updated the :root background color scheme to be more consistent. Now, regardless of the user's _browser_ dark/light preference, the site root will have the same background, resulting in a consistent map shade. 