### PR TITLE
Bump MapLibre version; add more labels; bold font

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/base": "^5.0.0-beta.40",
         "@mui/material": "^5.15.18",
         "apache-arrow": "^15.0.2",
-        "maplibre-gl": "^4.1.3",
+        "maplibre-gl": "^4.4.1",
         "pmtiles": "^3.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1174,9 +1174,10 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.2.0.tgz",
-      "integrity": "sha512-BTw6/3ysowky22QMtNDjElp+YLwwvBDh3xxnq1izDFjTtUERm5nYSihlNZ6QaxXb+6lX2T2t0hBEjheAI+kBEQ==",
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.0.tgz",
+      "integrity": "sha512-eSiQ3E5LUSxAOY9ABXGyfNhout2iEa6mUxKeaQ9nJ8NL1NuaQYU7zKqzx/LEYcXe1neT4uYAgM1wYZj3fTSXtA==",
+      "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -4346,7 +4347,8 @@
     "node_modules/json-stringify-pretty-compact": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4476,9 +4478,10 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.3.0.tgz",
-      "integrity": "sha512-lmv1iUJAWYde6KyGk0ln2WIJbQ/S3Fu3HZTQ9sCgVxPaB3X0aXJbFDsIer+kGrh2+ArhyuM7NzF1dB2nPl4bGQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.4.1.tgz",
+      "integrity": "sha512-tD+wn8qWSLCGhABKBrbewmgFfyopZDz+fkYXeOM8vdBhnf126DvMPyaYGGoKvoF4QuswCsgikETd2c39wK+OQw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -4487,7 +4490,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.2.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.0",
         "@types/geojson": "^7946.0.14",
         "@types/geojson-vt": "3.2.5",
         "@types/junit-report-builder": "^3.0.2",
@@ -4963,7 +4966,8 @@
     "node_modules/quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -5745,7 +5749,8 @@
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,7 @@
     "@mui/base": "^5.0.0-beta.40",
     "@mui/material": "^5.15.18",
     "apache-arrow": "^15.0.2",
-    "maplibre-gl": "^4.1.3",
+    "maplibre-gl": "^4.4.1",
     "pmtiles": "^3.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -88,6 +88,32 @@ const ThemeTypeLayer = ({
           layout={{ visibility: visible ? "visible" : "none" }}
         />
       ) : null}
+
+      {point ? (
+        <Layer
+          filter={["==", ["geometry-type"], "Point"]}
+          id={`${theme}_${type}_point_label`}
+          minzoom={17}
+          type="symbol"
+          source={theme}
+          source-layer={type}
+          paint={{
+            "text-color": "black",
+            "text-halo-color": colorExpression(color),
+            "text-halo-width": 1,
+          }}
+          layout={{
+            "text-font": ["Noto Sans Bold"],
+            "text-field": ["get", "@name"],
+            "text-size": 11,
+            visibility: visible ? "visible" : "none",
+            "text-variable-anchor": ["top", "bottom", "left", "right"],
+            "text-radial-offset": 0.8,
+            "text-justify": "auto",
+          }}
+        />
+      ) : null}
+
       {line ? (
         <Layer
           filter={["==", ["geometry-type"], "LineString"]}
@@ -97,6 +123,27 @@ const ThemeTypeLayer = ({
           source-layer={type}
           paint={{ "line-color": colorExpression(color) }}
           layout={{ visibility: visible ? "visible" : "none" }}
+        />
+      ) : null}
+      {line ? (
+        <Layer
+          filter={["==", ["geometry-type"], "LineString"]}
+          id={`${theme}_${type}_line_label`}
+          type="symbol"
+          source={theme}
+          source-layer={type}
+          paint={{
+            "text-color": "black",
+            "text-halo-color": colorExpression(color),
+            "text-halo-width": 1,
+          }}
+          layout={{
+            "text-font": ["Noto Sans Bold"],
+            "text-field": ["get", "@name"],
+            "text-size": 11,
+            "symbol-placement": "line-center",
+            visibility: visible ? "visible" : "none",
+          }}
         />
       ) : null}
       {polygon ? (
@@ -128,6 +175,27 @@ const ThemeTypeLayer = ({
             "fill-extrusion-height": ["get", "height"],
           }}
           layout={{ visibility: visible ? "visible" : "none" }}
+        />
+      ) : null}
+      {polygon || extrusion ? (
+        <Layer
+          filter={["all", ["==", ["geometry-type"], "Polygon"]]}
+          id={`${theme}_${type}_fill_labels`}
+          type="symbol"
+          source={theme}
+          source-layer={type}
+          paint={{
+            "text-color": "black",
+            "text-halo-color": colorExpression(color),
+            "text-halo-width": 1,
+          }}
+          layout={{
+            "text-font": ["Noto Sans Bold"],
+            "text-field": ["get", "@name"],
+            "text-size": 11,
+            visibility: visible ? "visible" : "none",
+            "symbol-placement": "point",
+          }}
         />
       ) : null}
     </>
@@ -177,7 +245,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
         setCursor("pointer");
       }
     },
-    [visibleThemes]
+    [visibleThemes],
   );
   const onMouseLeave = useCallback(() => setCursor("auto"), []);
 
@@ -202,7 +270,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
             sourceLayer: feature.sourceLayer,
             id: feature.id,
           },
-          { selected: true }
+          { selected: true },
         );
         setMapEntity({
           theme: feature.source,
@@ -213,7 +281,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
         setMapEntity({});
       }
     },
-    [visibleThemes]
+    [visibleThemes],
   );
 
   const handleZoom = (event) => {
@@ -352,7 +420,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
               "text-halo-width": 1,
             }}
             layout={{
-              "text-font": ["Noto Sans Regular"],
+              "text-font": ["Noto Sans Bold"],
               "text-field": ["get", "@name"],
               "text-size": 11,
             }}


### PR DESCRIPTION
* Bump to latest version of MapLibre 4.4.1
* change default font to Noto Sans Bold instead of Regular
* add more label layers for themes, using the `@name` helper tag