### PR TITLE
Switch bucket to us-west-2 one

### DIFF
--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -18,7 +18,7 @@ import ThemeSelector from "./ThemeSelector";
 import BugIcon from "./icons/icon-bug.svg?react";
 
 const PMTILES_URL =
-  "pmtiles://https://data.source.coop/protomaps/overture/2024-06-13-beta.0/";
+  "pmtiles://https://hellocdkstack-overturetilesbucket6f38c611-6zusoghoh4au.s3.us-west-2.amazonaws.com/";
 
 const INITIAL_VIEW_STATE = {
   latitude: 51.05,

--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -18,7 +18,7 @@ import ThemeSelector from "./ThemeSelector";
 import BugIcon from "./icons/icon-bug.svg?react";
 
 const PMTILES_URL =
-  "pmtiles://https://hellocdkstack-overturetilesbucket6f38c611-6zusoghoh4au.s3.us-west-2.amazonaws.com/";
+  "pmtiles://https://hellocdkstack-overturetilesbucket6f38c611-6zusoghoh4au.s3.us-west-2.amazonaws.com/2024-06-13-beta/";
 
 const INITIAL_VIEW_STATE = {
   latitude: 51.05,


### PR DESCRIPTION
* new tilesets were built with more label tags and 2024-06-13-beta.1 release. [#70]