### PR TITLE
Tour button color

### DIFF
--- a/site/src/Tour.jsx
+++ b/site/src/Tour.jsx
@@ -175,6 +175,12 @@ function Tour({ run, modeName, setMapEntity }) {
           arrowColor: stepBGColor,
           textColor: stepTextColor,
         },
+        buttonNext: {
+          backgroundColor: "var(--ifm-color-primary)",
+        },
+        buttonBack: {
+          color: "var(--ifm-color-primary)",
+        },
       }}
       spotlightPadding={0}
     />

--- a/site/src/Tour.jsx
+++ b/site/src/Tour.jsx
@@ -175,18 +175,27 @@ function Tour({ run, modeName, setMapEntity }) {
           arrowColor: stepBGColor,
           textColor: stepTextColor,
         },
-        buttonNext: {
-          backgroundColor: "var(--ifm-color-primary)",
-        },
+        buttonNext:
+          modeName === "theme-dark"
+            ? {
+                backgroundColor: "var(--ifm-color-primary-lightest)",
+                color: stepBGColor,
+                fontWeight: "600",
+              }
+            : {
+                backgroundColor: "var(--ifm-color-primary)",
+                fontWeight: "600",
+              },
         buttonBack:
           modeName === "theme-dark"
             ? {
-                color: "var(--ifm-color-primary)",
-                backgroundColor: "var(--ifm-color-secondary-light)",
+                color: "var(--ifm-color-primary-lightest)",
+                fontWeight: "600",
                 opacity: "90%",
                 borderRadius: "4px",
               }
-            : { color: "var(--ifm-color-primary)" },
+            : { color: "var(--ifm-color-primary)", fontWeight: "600" },
+        buttonSkip: { fontWeight: "600" },
       }}
       spotlightPadding={0}
     />

--- a/site/src/Tour.jsx
+++ b/site/src/Tour.jsx
@@ -178,9 +178,15 @@ function Tour({ run, modeName, setMapEntity }) {
         buttonNext: {
           backgroundColor: "var(--ifm-color-primary)",
         },
-        buttonBack: {
-          color: "var(--ifm-color-primary)",
-        },
+        buttonBack:
+          modeName === "theme-dark"
+            ? {
+                color: "var(--ifm-color-primary)",
+                backgroundColor: "var(--ifm-color-secondary-light)",
+                opacity: "90%",
+                borderRadius: "4px",
+              }
+            : { color: "var(--ifm-color-primary)" },
       }}
       spotlightPadding={0}
     />


### PR DESCRIPTION
The tour next/back button coloring has been updated to be more in line with the rest of the site color scheme. Below are examples of how these new buttons look in light and dark modes.
![Screenshot 2024-06-27 at 11 19 10 AM](https://github.com/OvertureMaps/io-site/assets/69924736/10d8c3f4-7095-4f1a-af8b-e9f496520dc1)
![Screenshot 2024-06-27 at 11 19 19 AM](https://github.com/OvertureMaps/io-site/assets/69924736/950c98c2-3032-4a99-8311-a8b7e6f24a37)
