### PR TITLE
Address theme

### DIFF
--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -19,6 +19,8 @@ import BugIcon from "./icons/icon-bug.svg?react";
 const PMTILES_URL =
   "pmtiles://https://d32gfzcnkb85e2.cloudfront.net/2024-06-13-beta/";
 
+const ADDRESS_URL = "pmtiles://https://protomaps.dev/~bdon/";
+
 const INITIAL_VIEW_STATE = {
   latitude: 51.05,
   longitude: 3.7303,
@@ -244,7 +246,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
         setCursor("pointer");
       }
     },
-    [visibleThemes],
+    [visibleThemes]
   );
   const onMouseLeave = useCallback(() => setCursor("auto"), []);
 
@@ -269,7 +271,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
             sourceLayer: feature.sourceLayer,
             id: feature.id,
           },
-          { selected: true },
+          { selected: true }
         );
         setMapEntity({
           theme: feature.source,
@@ -280,7 +282,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
         setMapEntity({});
       }
     },
-    [visibleThemes],
+    [visibleThemes]
   );
 
   const handleZoom = (event) => {
@@ -315,6 +317,7 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
           <ThemeSource name="places" url={PMTILES_URL} />
           <ThemeSource name="divisions" url={PMTILES_URL} />
           <ThemeSource name="transportation" url={PMTILES_URL} />
+          <ThemeSource name="addresses" url={ADDRESS_URL} />
 
           <ThemeTypeLayer
             theme="base"
@@ -407,6 +410,13 @@ export default function Map({ mode, mapEntity, setMapEntity, setZoom }) {
             point
             color="#fdb462"
             visible={visibleThemes.includes("places")}
+          />
+          <ThemeTypeLayer
+            theme="addresses"
+            type="address"
+            point
+            color="#00FFFF"
+            visible={visibleThemes.includes("addresses")}
           />
           <Layer
             id="divisions_division"

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -9,6 +9,7 @@ function ThemeSelector({ visibleThemes, mode }) {
   const [divisions, setDivisions] = useState(true);
   const [places, setPlaces] = useState(true);
   const [transportation, setTransportation] = useState(true);
+  const [addresses, setAddresses] = useState(true);
 
   useEffect(() => {
     let layers = [];
@@ -18,8 +19,17 @@ function ThemeSelector({ visibleThemes, mode }) {
     if (divisions) layers.push("divisions");
     if (places) layers.push("places");
     if (transportation) layers.push("transportation");
+    if (addresses) layers.push("addresses");
     visibleThemes(layers);
-  }, [base, buildings, divisions, places, transportation, visibleThemes]);
+  }, [
+    base,
+    buildings,
+    divisions,
+    places,
+    transportation,
+    addresses,
+    visibleThemes,
+  ]);
 
   return (
     <div className="dropdown dropdown--hoverable theme-selector tour-layers">
@@ -84,6 +94,17 @@ function ThemeSelector({ visibleThemes, mode }) {
               onChange={() => setTransportation(!transportation)}
             />
             Transportation
+          </label>
+        </li>
+        <li>
+          <label htmlFor="addresses" className="dropdown__link">
+            <input
+              id="addresses"
+              type="checkbox"
+              checked={addresses}
+              onChange={() => setAddresses(!addresses)}
+            />
+            Addresses
           </label>
         </li>
       </ul>

--- a/site/src/inspector_panel/InspectorPanel.jsx
+++ b/site/src/inspector_panel/InspectorPanel.jsx
@@ -9,6 +9,7 @@ import {
   DIVISION_TIPS,
   PLACES_TIPS,
   TRANSPORTATION_TIPS,
+  ADDRESSES_TIPS,
 } from "./TipLibrary";
 
 function InspectorPanel({ mode, entity, setEntity }) {
@@ -39,6 +40,10 @@ function InspectorPanel({ mode, entity, setEntity }) {
   } else if (theme === "transportation") {
     inspectorPanel = (
       <ThemePanel mode={mode} entity={entity} tips={TRANSPORTATION_TIPS} />
+    );
+  } else if (theme === "addresses") {
+    inspectorPanel = (
+      <ThemePanel mode={mode} entity={entity} tips={ADDRESSES_TIPS} />
     );
   } else {
     console.log("unhandled theme type");

--- a/site/src/inspector_panel/TipLibrary.jsx
+++ b/site/src/inspector_panel/TipLibrary.jsx
@@ -85,3 +85,5 @@ export const PLACES_TIPS = {
   id: PLACES_ID,
   source: PLACES_SOURCE,
 };
+
+export const ADDRESSES_TIPS = {};

--- a/site/src/inspector_panel/TipLibrary.jsx
+++ b/site/src/inspector_panel/TipLibrary.jsx
@@ -86,4 +86,18 @@ export const PLACES_TIPS = {
   source: PLACES_SOURCE,
 };
 
-export const ADDRESSES_TIPS = {};
+const ADDRESSES_THEME = "";
+const ADDRESSES_TYPE =
+  "Describes the entity. The addresses theme only has one type: address.";
+const ADDRESSES_SUBTYPE = "";
+const ADDRESSES_ID =
+  "A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS.";
+const ADDRESSES_SOURCE =
+  "The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified.";
+export const ADDRESSES_TIPS = {
+  theme: ADDRESSES_THEME,
+  type: ADDRESSES_TYPE,
+  subtype: ADDRESSES_SUBTYPE,
+  id: ADDRESSES_ID,
+  source: ADDRESSES_SOURCE,
+};


### PR DESCRIPTION
This change adds the address theme data to the explore site. Below is a quick demo showing the address data in action. The address points are shown using the cyan color. The points are also the same size and style as connector points of the `transportation` theme and places of the `place` theme. You will notice that the layer is not visible at zoom less than 14. This is a feature of the pmtile dataset. You will also see that the inspector panel does not currently highlight any specific properties of the data - this is done to expedite the initial viewing of the data via the explore site. I am awaiting the official schema and docs pages to be available for the address theme to fully dive into customizing the inspector theme for addresses. Feedback is also encouraged so the panel can better serve our purposes.

https://github.com/user-attachments/assets/223afe8e-5c8a-4008-b1b2-d5f9fed5d27d

