### PR TITLE
Theme selector restyle

### DIFF
--- a/site/src/ThemeSelector.css
+++ b/site/src/ThemeSelector.css
@@ -45,6 +45,8 @@ svg.icon-layers > path.secondary {
 .theme-selector-popover {
   max-height: 80vh;
   overflow-y: auto;
+  overflow-x:hidden;
+  border:1px solid #888888;
 }
 
 label.type-selector-checkbox {

--- a/site/src/ThemeSelector.css
+++ b/site/src/ThemeSelector.css
@@ -44,7 +44,7 @@ svg.icon-layers > path.secondary {
 
 .theme-selector-popover {
   max-height: 80vh;
-  overflow-y: hidden;
+  overflow-y: auto;
 }
 
 label.type-selector-checkbox {

--- a/site/src/ThemeSelector.css
+++ b/site/src/ThemeSelector.css
@@ -46,3 +46,25 @@ svg.icon-layers > path.secondary {
   max-height: 80vh;
   overflow-y: scroll;
 }
+
+label.type-selector-checkbox {
+  margin:0px;
+  padding:0px;
+}
+
+.type-selector-checkbox > span { 
+  font-weight:400;
+  font-size:small;
+  color:#dddddd;
+  font-style:italic
+}
+
+.type-selector-checkbox > span { 
+  color:#333333;
+  font-style:italic
+}
+
+.type-selector-checkbox.dark > span { 
+  color:#cccccc;
+  font-style:italic
+}

--- a/site/src/ThemeSelector.css
+++ b/site/src/ThemeSelector.css
@@ -44,7 +44,7 @@ svg.icon-layers > path.secondary {
 
 .theme-selector-popover {
   max-height: 80vh;
-  overflow-y: scroll;
+  overflow-y: hidden;
 }
 
 label.type-selector-checkbox {

--- a/site/src/ThemeSelector.css
+++ b/site/src/ThemeSelector.css
@@ -68,3 +68,11 @@ label.type-selector-checkbox {
   color:#cccccc;
   font-style:italic
 }
+
+.theme-box:nth-child(even) {
+  background:#eeeeee;
+}
+
+.theme-box.dark:nth-child(even) {
+  background:#333333;
+}

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -138,7 +138,7 @@ const ThemeSelector = ({
         {activeThemes.includes(theme) ? (
           <PushPinIcon {...props} />
         ) : (
-          <PushPinOutlinedIcon {...props} sx={{strokeWidth:2}}/>
+          <PushPinOutlinedIcon {...props}/>
         )}
       </IconButton>
     );

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -98,13 +98,13 @@ const ThemeSelector = ({
     });
   };
 
-  const renderPinThemeIcon = (theme) => {
+  const renderPinThemeIcon = (theme, mode) => {
     const props = {
       sx: {
         "&:hover": {
           cursor: "pointer",
         },
-        color: "black",
+        color: mode==='theme-dark' ? "white" : "black",
       },
     };
 
@@ -119,7 +119,7 @@ const ThemeSelector = ({
           }
         }}
         sx={{
-          marginTop: "-7px",
+          marginTop: "-2px",
         }}
       >
         {activeThemes.includes(theme) ? (
@@ -144,7 +144,7 @@ const ThemeSelector = ({
           const children = types.map((t) => selectedTypes[t.type]);
 
           return (
-            <Grid container width={200}>
+            <Grid container sx={{paddingLeft:"5px"}}width={200}>
               <Grid
                 className={
                   theme === "divisions" ? "tour-layers-checkboxes" : ""
@@ -158,10 +158,13 @@ const ThemeSelector = ({
                     className="theme-selector-checkbox"
                     sx={{
                       height: "16px",
+                      marginBottom: "4px",
+                      marginTop:"10px"
                     }}
                     control={
                       <Checkbox
-                        size="small"
+                        size="medium"
+                        sx={{padding:'2px'}}
                         checked={
                           selectedThemes[theme] && children.includes(true)
                         }
@@ -174,13 +177,15 @@ const ThemeSelector = ({
                   />
                 </div>
                 {types.length > 1 && (
-                  <Box sx={{ display: "flex", flexDirection: "column", ml: 3 }}>
+                  <Box sx={{ display: "flex", flexDirection: "column", ml: 2, padding: "0px"}}>
                     {types.map((layer) => (
                       <FormControlLabel
                         label={format(layer.type)}
-                        className="theme-selector-checkbox"
+                        className=""
+                        className={`type-selector-checkbox ${mode === 'theme-dark' ? 'dark':'light'}`}
                         control={
                           <Checkbox
+                            sx={{padding:'2px'}}
                             size="small"
                             checked={selectedTypes[layer.type]}
                             onChange={() => handleTypeChange(layer.type)}
@@ -192,7 +197,7 @@ const ThemeSelector = ({
                 )}
               </Grid>
               <Grid item xs={2}>
-                {renderPinThemeIcon(theme)}
+                {renderPinThemeIcon(theme, mode)}
               </Grid>
             </Grid>
           );

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -15,6 +15,19 @@ import {
 import PushPinIcon from "@mui/icons-material/PushPin";
 import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
 
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+const muiTheme = createTheme({
+  typography: {
+    allVariants: {
+      "fontFamily": `Montserrat, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans,sans-serif`,
+      "fontSize": 14,
+      "fontWeightLight": 300,
+      "fontWeightRegular": 400,
+      "fontWeightMedium": 500   
+    }
+  }});
+
 const ThemeSelector = ({
   mode,
   setVisibleTypes,
@@ -135,74 +148,76 @@ const ThemeSelector = ({
     const themes = [...new Set(layers.map((layer) => layer.theme))];
 
     return (
-      <Box p={1} className>
-        {themes.map((theme) => {
-          const types = filterUniqueByType(
-            layers.filter((layer) => layer.theme === theme)
-          );
+      <ThemeProvider theme={muiTheme}>
+        <Box p={1} className>
+          {themes.map((theme) => {
+            const types = filterUniqueByType(
+              layers.filter((layer) => layer.theme === theme)
+            );
 
-          const children = types.map((t) => selectedTypes[t.type]);
+            const children = types.map((t) => selectedTypes[t.type]);
 
-          return (
-            <Grid container className={`theme-box ${mode === 'theme-dark' ? 'dark':'light'}`}  sx={{paddingLeft:"5px"}} width={200}>
-              <Grid
-                className={
-                  theme === "divisions" ? "tour-layers-checkboxes" : ""
-                }
-                item
-                xs={10}
-              >
-                <div>
-                  <FormControlLabel
-                    label={format(theme)}
-                    className="theme-selector-checkbox"
-                    sx={{
-                      height: "16px",
-                      marginBottom: "4px",
-                      marginTop:"10px"
-                    }}
-                    control={
-                      <Checkbox
-                        size="small"
-                        sx={{padding:'2px'}}
-                        checked={
-                          selectedThemes[theme] && children.includes(true)
-                        }
-                        indeterminate={
-                          children.includes(true) && children.includes(false)
-                        }
-                        onChange={() => handleThemeChange(theme)}
-                      />
-                    }
-                  />
-                </div>
-                {types.length > 1 && (
-                  <Box sx={{ display: "flex", flexDirection: "column", ml: 2, padding: "0px"}}>
-                    {types.map((layer) => (
-                      <FormControlLabel
-                        label={format(layer.type)}
-                        className=""
-                        className={`type-selector-checkbox ${mode === 'theme-dark' ? 'dark':'light'}`}
-                        control={
-                          <Checkbox
-                            sx={{padding:'2px'}}
-                            size="small"
-                            checked={selectedTypes[layer.type]}
-                            onChange={() => handleTypeChange(layer.type)}
-                          />
-                        }
-                      />
-                    ))}
-                  </Box>
-                )}
+            return (
+              <Grid container className={`theme-box ${mode === 'theme-dark' ? 'dark':'light'}`}  sx={{paddingLeft:"5px"}} width={200}>
+                <Grid
+                  className={
+                    theme === "divisions" ? "tour-layers-checkboxes" : ""
+                  }
+                  item
+                  xs={10}
+                >
+                  <div>
+                    <FormControlLabel
+                      label={format(theme)}
+                      className="theme-selector-checkbox"
+                      sx={{
+                        height: "16px",
+                        marginBottom: "4px",
+                        marginTop:"10px"
+                      }}
+                      control={
+                        <Checkbox
+                          size="small"
+                          sx={{padding:'2px'}}
+                          checked={
+                            selectedThemes[theme] && children.includes(true)
+                          }
+                          indeterminate={
+                            children.includes(true) && children.includes(false)
+                          }
+                          onChange={() => handleThemeChange(theme)}
+                        />
+                      }
+                    />
+                  </div>
+                  {types.length > 1 && (
+                    <Box sx={{ display: "flex", flexDirection: "column", ml: 2, padding: "0px"}}>
+                      {types.map((layer) => (
+                        <FormControlLabel
+                          label={format(layer.type)}
+                          className=""
+                          className={`type-selector-checkbox ${mode === 'theme-dark' ? 'dark':'light'}`}
+                          control={
+                            <Checkbox
+                              sx={{padding:'2px'}}
+                              size="small"
+                              checked={selectedTypes[layer.type]}
+                              onChange={() => handleTypeChange(layer.type)}
+                            />
+                          }
+                        />
+                      ))}
+                    </Box>
+                  )}
+                </Grid>
+                <Grid item xs={2}>
+                  {renderPinThemeIcon(theme, mode)}
+                </Grid>
               </Grid>
-              <Grid item xs={2}>
-                {renderPinThemeIcon(theme, mode)}
-              </Grid>
-            </Grid>
-          );
-        })}
-      </Box>
+            );
+          })}
+        </Box>
+      </ThemeProvider>
     );
   };
 

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -149,7 +149,7 @@ const ThemeSelector = ({
 
     return (
       <ThemeProvider theme={muiTheme}>
-        <Box p={1} className>
+        <Box p={1} className sx={{padding:"0px"}}>
           {themes.map((theme) => {
             const types = filterUniqueByType(
               layers.filter((layer) => layer.theme === theme)
@@ -178,7 +178,7 @@ const ThemeSelector = ({
                       control={
                         <Checkbox
                           size="small"
-                          sx={{padding:'2px'}}
+                          sx={{padding:'2px', ml:1}}
                           checked={
                             selectedThemes[theme] && children.includes(true)
                           }

--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -125,7 +125,7 @@ const ThemeSelector = ({
         {activeThemes.includes(theme) ? (
           <PushPinIcon {...props} />
         ) : (
-          <PushPinOutlinedIcon {...props} />
+          <PushPinOutlinedIcon {...props} sx={{strokeWidth:2}}/>
         )}
       </IconButton>
     );
@@ -144,7 +144,7 @@ const ThemeSelector = ({
           const children = types.map((t) => selectedTypes[t.type]);
 
           return (
-            <Grid container sx={{paddingLeft:"5px"}}width={200}>
+            <Grid container className={`theme-box ${mode === 'theme-dark' ? 'dark':'light'}`}  sx={{paddingLeft:"5px"}} width={200}>
               <Grid
                 className={
                   theme === "divisions" ? "tour-layers-checkboxes" : ""
@@ -163,7 +163,7 @@ const ThemeSelector = ({
                     }}
                     control={
                       <Checkbox
-                        size="medium"
+                        size="small"
                         sx={{padding:'2px'}}
                         checked={
                           selectedThemes[theme] && children.includes(true)


### PR DESCRIPTION
This PR begins to address #108 with a number of styling updates to the theme/type selector. 

UPDATE: After PR Feedback from Ethan and Charlie I've adjusted the styling a bit. Great comments and I think it's an improvement. 

![image](https://github.com/user-attachments/assets/03856acf-755f-46c9-9856-c4c5d39085a8)



Here is a before/after pic: 

Dark Mode: 
![image](https://github.com/user-attachments/assets/16dd02d5-95c4-4c70-a271-f6059f74fe40)

Light Mode:
![image](https://github.com/user-attachments/assets/f696a2f4-5cb6-425a-bd23-d987a6d1892a)
