### PR TITLE
Fix warning in console: building heights

### DIFF
--- a/site/src/ThemeTypeLayer.jsx
+++ b/site/src/ThemeTypeLayer.jsx
@@ -168,6 +168,7 @@ const ThemeTypeLayer = ({
             "all",
             ["==", ["geometry-type"], "Polygon"],
             ["!=", ["get", "has_parts"], true],
+            ["has", "height"]
           ]} // prevent z-fighting
           id={`${theme}_${type}_fill-extrusion`}
           type="fill-extrusion"
@@ -180,7 +181,7 @@ const ThemeTypeLayer = ({
                 ? 0.5
                 : 0.7
               : 0.35,
-            "fill-extrusion-base": ["get", "min_height"],
+            "fill-extrusion-base": ["coalesce",["get", "min_height"],0],
             "fill-extrusion-height": ["get", "height"],
           }}
           layout={{ visibility: visible ? "visible" : "none" }}


### PR DESCRIPTION
Limit fill-extrusion layers to building parts with heights, and set min_height to 0 if null.

Fixes the warnings in the console on loading explore.overturemaps.org:

```
Expected value to be of type number, but found null instead.
```