### PR TITLE
Fix an issue that was causing the current selected themes to become d…

### DIFF
--- a/site/src/ThemeSelector.jsx
+++ b/site/src/ThemeSelector.jsx
@@ -19,6 +19,39 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 
+// Should convert this logic to be dynamic once manifests are a thing!
+function themeFromType (type) {
+  switch (type) {
+    case "boundary":
+    case "division":
+    case "division_area":
+    case "division_boundary":
+      return 'divisions';
+
+    case "land":
+    case "land_cover":
+    case "land_use":
+    case "water":
+    case "infrastructure":
+      return "base";
+
+    case "segment":
+    case "connector":
+      return "transportation";
+
+    case "building":
+    case "building_part":
+      return "buildings"
+
+    case "place":
+      return "places";
+
+    case "address":
+      return "addresses"
+  }
+  return '';
+}
+
 const muiTheme = createTheme({
   typography: {
     allVariants: {
@@ -74,10 +107,15 @@ const ThemeSelector = ({
 
   useEffect(() => {
     const newSelectedTypes = {};
+    const newSelectedThemes = {};
+
     visibleTypes.forEach((type) => {
       newSelectedTypes[type] = true;
+      newSelectedThemes[themeFromType(type)] = true;
     });
+
     setSelectedTypesState(newSelectedTypes);
+    setSelectedThemes(newSelectedThemes);
   }, [visibleTypes]);
 
   const handleThemeChange = (theme) => {


### PR DESCRIPTION
…esynced after the navigator was used.

When any of the navigator options are clicked, such as 'Paris Roads', the site updates the current visible types with a call to a hook named 'setVisibleTypes' that accepts a list of type names to 'check' in the theme selector. 

The theme selector was missing the logic that would in turn update the current *themes* that should be considered 'enabled', which led all of them to still be set as 'ON' even though they weren't checked. 

So, after clicking paris roads, the 'Addresses' checkbox would be unchecked, but the 'visibleThemes' would have 'Addresses = True'. This is what caused the need to click the checkbox twice afterwards- the first time toggled true to false, the second time toggled back from false to true, checking the box. 