### PR TITLE
Add bathymetry outline layer to base theme.

### DIFF
--- a/site/src/Layers.js
+++ b/site/src/Layers.js
@@ -11,6 +11,13 @@ export const layers = [
   },
   {
     theme: "base",
+    type: "bathymetry",
+    outline: true,
+    color: "hsla(195, 71%, 80%, 1)",
+    activeColor: "hsla(195, 77%, 85%, 1)",
+  },
+  {
+    theme: "base",
     type: "land",
     polygon: true,
     point: true,

--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -40,7 +40,13 @@ const MAP_STYLE = {
 };
 
 const ThemeSource = ({ name, url }) => {
-  return <Source id={name} type="vector" url={`${url}${name}.pmtiles`} />;
+  return (
+    <Source
+      id={name}
+      type="vector"
+      url={`${url}${name}${name === "base" ? "_canary" : ""}.pmtiles`}
+    />
+  );
 };
 
 ThemeSource.propTypes = {

--- a/site/src/ThemeTypeLayer.jsx
+++ b/site/src/ThemeTypeLayer.jsx
@@ -141,6 +141,22 @@ const ThemeTypeLayer = ({
           {...(minzoom ? { minzoom } : {})}
         />
       ) : null}
+      {outline ? (
+        <Layer
+          filter={["==", ["geometry-type"], "Polygon"]}
+          id={`${theme}_${type}_outline_click_buffer`}
+          type="line"
+          source={theme}
+          source-layer={type}
+          paint={{
+            "line-opacity": 0,
+            "line-color": "black",
+            "line-width": ["interpolate", ["linear"], ["zoom"], 12, 6, 13, 9],
+          }}
+          layout={{ visibility: visible ? "visible" : "none" }}
+          {...(minzoom ? { minzoom } : {})}
+        />
+      ) : null}
       {label && line ? (
         <Layer
           filter={["==", ["geometry-type"], "LineString"]}


### PR DESCRIPTION
This PR adds bathymetry to the Overture Explorer. 

https://explore.overturemaps.org/aria/c5ab0ff-20.x-aria.html#3.31/38.7/-42.62

<img width="1512" alt="Screenshot 2024-12-20 at 11 30 10 AM" src="https://github.com/user-attachments/assets/2db53b7b-bb4e-4bf7-8279-9ef3705a0f85" />
