### PR TITLE
[SECURITY] Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     commit-message:
       prefix: "[CHORE](deps)"
       include: "scope"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read # required to checkout the code from the repo
-  pages: write # required to deploy to GitHub Pages
-  id-token: write # required to use OIDC authentication
 
 concurrency:
   group: "pages"
@@ -21,15 +19,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: package.json
 
@@ -48,10 +48,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: out
 
@@ -59,6 +59,9 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-slim
     needs: build
+    permissions:
+      pages: write # required to deploy to GitHub Pages
+      id-token: write # required to use OIDC authentication
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -66,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,5 +1,10 @@
 ---
-# This workflow builds and deploys to GitHub Pages
+# Production Deployment Workflow
+#
+# Triggered on: push to main
+# Jobs:
+#   - build:  Installs dependencies, runs tests, builds the site, and uploads a Pages artifact
+#   - deploy: Deploys the artifact to GitHub Pages via OIDC
 
 name: Production Deployment
 run-name: Publish prod site

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,23 +9,27 @@ on:
     branches: [ main ]
 
 permissions:
-  id-token: write # required to use OIDC authentication
   contents: read # required to checkout the code from the repo
-  pull-requests: write # required to comment on the PR with the staging URL
+
+concurrency:
+  group: staging-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version-file: package.json
 
@@ -44,15 +48,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version-file: package.json
 
@@ -71,7 +77,7 @@ jobs:
         BASEURL: ${{ github.event.repository.name }}/pr/${{ github.event.number }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: build-artifact
         path: out
@@ -80,17 +86,19 @@ jobs:
   a11y:
     name: Accessibility
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # No basePath — built at root so the local test server can resolve assets
     # The deployment build (with BASEURL) is tested separately via the build job
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: package.json
 
@@ -113,6 +121,10 @@ jobs:
     name: Deploy
     runs-on: ubuntu-slim
     needs: [test, build, a11y]
+    permissions:
+      id-token: write # required to use OIDC authentication
+      contents: read
+      pull-requests: write # required to comment on the PR with the staging URL
     environment:
       name: staging
       url: ${{ steps.deploy_url.outputs.url }}
@@ -120,32 +132,35 @@ jobs:
     steps:
       - name: Set deploy URL
         id: deploy_url
-        run: echo "url=https://staging.overturemaps.org/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${{ github.event.number }}/index.html" >> $GITHUB_OUTPUT
+        run: echo "url=https://staging.overturemaps.org/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${PR_NUMBER}/index.html" >> $GITHUB_OUTPUT
         env:
           GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::763944545891:role/pages-staging-oidc-overturemaps
           aws-region: us-west-2
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifact
           path: build
 
       - name: Copy to S3
         run: |
-          aws s3 sync --delete build s3://overture-managed-staging-usw2/gh-pages/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${{ github.event.number }}/
+          aws s3 sync --delete build s3://overture-managed-staging-usw2/gh-pages/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${PR_NUMBER}/
         env:
           GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Bust the Cache
-        run: aws cloudfront create-invalidation --distribution-id E1KP2IN0H2RGGT --paths "/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${{ github.event.number }}/*"
+        run: aws cloudfront create-invalidation --distribution-id E1KP2IN0H2RGGT --paths "/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${PR_NUMBER}/*"
         env:
           GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Get deploy timestamp
         id: timestamp

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Node.js
       uses: actions/setup-node@v6
@@ -46,6 +48,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Node.js
       uses: actions/setup-node@v6
@@ -82,6 +86,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -114,7 +120,9 @@ jobs:
     steps:
       - name: Set deploy URL
         id: deploy_url
-        run: echo "url=https://staging.overturemaps.org/${{ github.event.repository.name }}/pr/${{ github.event.number }}/index.html" >> $GITHUB_OUTPUT
+        run: echo "url=https://staging.overturemaps.org/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${{ github.event.number }}/index.html" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -130,10 +138,14 @@ jobs:
 
       - name: Copy to S3
         run: |
-          aws s3 sync --delete build s3://overture-managed-staging-usw2/gh-pages/${{ github.event.repository.name }}/pr/${{ github.event.number }}/
+          aws s3 sync --delete build s3://overture-managed-staging-usw2/gh-pages/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${{ github.event.number }}/
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Bust the Cache
-        run: aws cloudfront create-invalidation --distribution-id E1KP2IN0H2RGGT --paths "/${{ github.event.repository.name }}/pr/${{ github.event.number }}/*"
+        run: aws cloudfront create-invalidation --distribution-id E1KP2IN0H2RGGT --paths "/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${{ github.event.number }}/*"
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Get deploy timestamp
         id: timestamp

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,12 @@
 ---
-# This workflow will do a clean install of node dependencies and deploy to AWS.
+# Staging Deploy Workflow
+#
+# Triggered on: pull requests targeting main
+# Jobs:
+#   - test:   Lints and runs unit tests
+#   - build:  Builds the site with a PR-specific base URL and uploads artifacts
+#   - a11y:   Runs accessibility tests against the root build
+#   - deploy: Syncs build to S3, invalidates CloudFront cache, and comments the staging URL on the PR
 
 name: Staging Deploy
 run-name: Publish staging site


### PR DESCRIPTION
Harden GitHub workflows against findings from zizmor static analysis.

Once fixed, the new OMF Security Checks workflow will be required for PRs here, keeping a stable baseline of GH Actions secure-by-default.