### PR TITLE
[FEATURE] disable base layer selection in explore mode below zoom 10

### DIFF
--- a/components/MapView.jsx
+++ b/components/MapView.jsx
@@ -207,6 +207,10 @@ export default function Map({
       const seenIds = new Set();
 
       for (const feature of queriedFeatures) {
+        if (map.getZoom() < 10 && !inspectActiveRef.current && feature.source === "base") {
+          continue;
+        }
+
         if (isTypeVisible(feature.layer["source-layer"], currentVisibleTypes)) {
           if (!seenIds.has(feature.properties.id)) {
             clickedFeatures.push(feature);


### PR DESCRIPTION
* the features are still selectable in Inspect mode.

Resolves #258