### PR TITLE
[FEATURE] improve contrast of divisions and buildings inspect mode

### DIFF
--- a/components/map/layers/inspect/divisions/division-boundary/line.json
+++ b/components/map/layers/inspect/divisions/division-boundary/line.json
@@ -12,6 +12,6 @@
   "paint": {
     "line-color": "$inspect.division.color.line",
     "line-width": 1.5,
-    "line-opacity": "$inspect.division.opacity"
+    "line-opacity": 0.75
   }
 }

--- a/components/map/layers/inspect/divisions/division/label.json
+++ b/components/map/layers/inspect/divisions/division/label.json
@@ -41,6 +41,6 @@
   },
   "paint": {
     "text-color": "$inspect.division.color.text",
-    "text-opacity": 0.75
+    "text-opacity": 1.0
   }
 }

--- a/components/map/layers/inspect/divisions/division/label.json
+++ b/components/map/layers/inspect/divisions/division/label.json
@@ -36,7 +36,8 @@
       16
     ],
     "text-max-width": 8,
-    "text-allow-overlap": false
+    "text-allow-overlap": false,
+    "text-offset": [0, 0.75]
   },
   "paint": {
     "text-color": "$inspect.division.color.text",

--- a/components/map/tokens/semantic/inspect/colors.json
+++ b/components/map/tokens/semantic/inspect/colors.json
@@ -35,20 +35,20 @@
   "division": {
     "primary": "$globals.color.purple",
     "secondary": "$globals.color.gray.500",
-    "label": "$globals.color.purple",
+    "label": "$globals.color.white.50",
     "opacity": 0.05
   },
   "building": {
     "primary": "$globals.color.red.500",
     "secondary": "$globals.color.red.500",
     "label": "$globals.color.red.500",
-    "opacity": 0.25
+    "opacity": 0.50
   },
   "building_part": {
     "primary": "$globals.color.rose.200",
     "secondary": "$globals.color.rose.200",
     "label": "$globals.color.rose.200",
-    "opacity": 0.25
+    "opacity": 0.50
   },
   "place": {
     "primary": "$globals.color.indigo.500",

--- a/components/map/tokens/semantic/inspect/colors.json
+++ b/components/map/tokens/semantic/inspect/colors.json
@@ -35,7 +35,7 @@
   "division": {
     "primary": "$globals.color.purple",
     "secondary": "$globals.color.gray.500",
-    "label": "$globals.color.white.50",
+    "label": "$globals.color.gray.500",
     "opacity": 0.05
   },
   "building": {


### PR DESCRIPTION
* intensify color of buildings
* make division labels white for better contrast
* offset division labels to not overlap point symbol

Resolves #279