### PR TITLE
[FEATURE] Download as single archive instead of multi-file + supply metadata.json for download context

### DIFF
--- a/__tests__/downloadMetadata.test.js
+++ b/__tests__/downloadMetadata.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tests for lib/downloadMetadata.js
+ *
+ * Pure-function tests — no DOM, no mocks. `now` is injected so the
+ * `generatedAt` field is deterministic.
+ */
+
+import { buildDownloadMetadata } from "@/lib/downloadMetadata";
+
+const FIXED_NOW = new Date("2026-01-15T12:34:56.000Z");
+
+const baseInput = {
+  bbox: [-77.6904949, 39.1365536, -77.68, 39.15],
+  releaseVersion: "2024-09-18",
+  layers: ["buildings", "places"],
+  viewUrl: "https://explore.overturemaps.org/#15.42/39.13/-77.69",
+  now: FIXED_NOW,
+};
+
+describe("buildDownloadMetadata", () => {
+  it("produces parseable JSON with all expected fields", () => {
+    const json = buildDownloadMetadata(baseInput);
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toEqual({
+      source: "https://explore.overturemaps.org/",
+      bboxString: "-77.6904949,39.1365536,-77.68,39.15",
+      bbox: { west: -77.6904949, south: 39.1365536, east: -77.68, north: 39.15 },
+      release: "2024-09-18",
+      layers: ["buildings", "places"],
+      generatedAt: "2026-01-15T12:34:56.000Z",
+      viewUrl: "https://explore.overturemaps.org/#15.42/39.13/-77.69",
+    });
+  });
+
+  it("emits a bboxString in the exact format overturemaps-py / DuckDB accept", () => {
+    // Format is `west,south,east,north` with no spaces — this is the contract.
+    // Don't break it without updating downstream tooling docs.
+    const json = buildDownloadMetadata(baseInput);
+    expect(JSON.parse(json).bboxString).toBe(
+      "-77.6904949,39.1365536,-77.68,39.15"
+    );
+  });
+
+  it("preserves full coordinate precision (does not round)", () => {
+    // The filenames use 3-decimal precision for brevity, but metadata must
+    // round-trip the exact bbox the user queried with.
+    const json = buildDownloadMetadata({
+      ...baseInput,
+      bbox: [-77.69049491234567, 39.13655361234567, -77.68, 39.15],
+    });
+    const parsed = JSON.parse(json);
+    expect(parsed.bbox.west).toBe(-77.69049491234567);
+    expect(parsed.bbox.south).toBe(39.13655361234567);
+  });
+
+  it("omits viewUrl when not provided (e.g. SSR / tests)", () => {
+    const json = buildDownloadMetadata({ ...baseInput, viewUrl: undefined });
+    const parsed = JSON.parse(json);
+    expect(parsed).not.toHaveProperty("viewUrl");
+  });
+
+  it("omits viewUrl when empty string", () => {
+    const json = buildDownloadMetadata({ ...baseInput, viewUrl: "" });
+    expect(JSON.parse(json)).not.toHaveProperty("viewUrl");
+  });
+
+  it("sorts layers alphabetically for stable output across runs", () => {
+    const json = buildDownloadMetadata({
+      ...baseInput,
+      layers: ["transportation", "buildings", "places"],
+    });
+    expect(JSON.parse(json).layers).toEqual([
+      "buildings",
+      "places",
+      "transportation",
+    ]);
+  });
+
+  it("does not mutate the caller's layers array", () => {
+    const layers = ["zzz", "aaa"];
+    buildDownloadMetadata({ ...baseInput, layers });
+    expect(layers).toEqual(["zzz", "aaa"]);
+  });
+
+  it("accepts an empty layers array (download with no non-empty types is rejected upstream, but the helper itself is permissive)", () => {
+    const json = buildDownloadMetadata({ ...baseInput, layers: [] });
+    expect(JSON.parse(json).layers).toEqual([]);
+  });
+
+  it("uses the current time when `now` is omitted", () => {
+    const before = Date.now();
+    const json = buildDownloadMetadata({ ...baseInput, now: undefined });
+    const after = Date.now();
+    const ts = Date.parse(JSON.parse(json).generatedAt);
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("produces pretty-printed JSON (2-space indent) for human readability", () => {
+    const json = buildDownloadMetadata(baseInput);
+    expect(json).toMatch(/\n {2}"source":/);
+  });
+
+  describe("input validation", () => {
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["non-array", "not an array"],
+      ["wrong length (3)", [1, 2, 3]],
+      ["wrong length (5)", [1, 2, 3, 4, 5]],
+      ["contains NaN", [NaN, 0, 1, 2]],
+      ["contains Infinity", [0, 0, Infinity, 2]],
+      ["contains string", [0, 0, "1", 2]],
+    ])("rejects bbox that is %s", (_label, bbox) => {
+      expect(() => buildDownloadMetadata({ ...baseInput, bbox })).toThrow(
+        TypeError
+      );
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["empty string", ""],
+      ["number", 42],
+    ])("rejects releaseVersion that is %s", (_label, releaseVersion) => {
+      expect(() =>
+        buildDownloadMetadata({ ...baseInput, releaseVersion })
+      ).toThrow(TypeError);
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["string", "buildings"],
+      ["object", { 0: "buildings" }],
+    ])("rejects layers that is %s", (_label, layers) => {
+      expect(() => buildDownloadMetadata({ ...baseInput, layers })).toThrow(
+        TypeError
+      );
+    });
+  });
+});

--- a/__tests__/zipDownload.test.js
+++ b/__tests__/zipDownload.test.js
@@ -78,6 +78,47 @@ describe("buildZip", () => {
   it("throws when a file is missing data", () => {
     expect(() => buildZip([{ name: "a.txt" }])).toThrow(/missing.*data/);
   });
+
+  it("accepts ArrayBuffer entries by wrapping them in a Uint8Array", () => {
+    const buf = new ArrayBuffer(4);
+    new Uint8Array(buf).set([0xde, 0xad, 0xbe, 0xef]);
+
+    const zipped = buildZip([{ name: "x.bin", data: buf }]);
+    const unzipped = unzipSync(zipped);
+    expect(Array.from(unzipped["x.bin"])).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it.each([
+    ["number", 42],
+    ["plain object", { foo: "bar" }],
+    ["Blob", new Blob(["hello"])],
+    ["array", [1, 2, 3]],
+  ])("throws TypeError when data is an unsupported type (%s)", (_label, data) => {
+    expect(() => buildZip([{ name: "f.bin", data }])).toThrow(
+      /must have `data` as a string, Uint8Array, or ArrayBuffer/
+    );
+  });
+
+  it.each(["__proto__", "prototype", "constructor"])(
+    "rejects the reserved filename %s to prevent prototype pollution / fflate input collisions",
+    (name) => {
+      // Without this guard, "__proto__" would mutate Object.prototype on a
+      // plain-object map, and even Object.create(null) doesn't help because
+      // fflate's own input handling can't accept that key. See the lib comment.
+      const protoBefore = Object.prototype.toString;
+      expect(() => buildZip([{ name, data: "x" }])).toThrow(
+        /reserved and cannot be used/
+      );
+      expect(Object.prototype.toString).toBe(protoBefore);
+    }
+  );
+
+  it("does not pollute Object.prototype when zipping an ordinary archive", () => {
+    const protoBefore = Object.prototype.toString;
+    buildZip([{ name: "real.txt", data: "ok" }]);
+    expect(Object.prototype.toString).toBe(protoBefore);
+    expect({}.__proto__).toBe(Object.prototype);
+  });
 });
 
 describe("triggerBrowserDownload", () => {

--- a/__tests__/zipDownload.test.js
+++ b/__tests__/zipDownload.test.js
@@ -1,0 +1,227 @@
+/**
+ * Tests for lib/zipDownload.js
+ *
+ * Two scopes:
+ *   1. buildZip — pure function, verified by round-tripping through fflate's
+ *      unzipSync. No DOM, no mocks beyond fflate itself (which we trust).
+ *   2. triggerBrowserDownload / downloadAsZip — DOM side-effects verified by
+ *      injecting a stub document and stubbing URL.createObjectURL. No real
+ *      navigation occurs in jsdom; we assert the link element was constructed
+ *      with the right href/download attributes and click() was invoked.
+ */
+
+import { unzipSync, strFromU8 } from "fflate";
+import {
+  buildZip,
+  triggerBrowserDownload,
+  downloadAsZip,
+} from "@/lib/zipDownload";
+
+describe("buildZip", () => {
+  it("packages multiple string entries and round-trips through unzipSync", () => {
+    const files = [
+      { name: "a.geojson", data: '{"type":"FeatureCollection","features":[]}' },
+      { name: "b.geojson", data: '{"type":"FeatureCollection","features":[1]}' },
+    ];
+
+    const zipped = buildZip(files);
+    expect(zipped).toBeInstanceOf(Uint8Array);
+    expect(zipped.length).toBeGreaterThan(0);
+
+    const unzipped = unzipSync(zipped);
+    expect(Object.keys(unzipped).sort()).toEqual(["a.geojson", "b.geojson"]);
+    expect(strFromU8(unzipped["a.geojson"])).toBe(files[0].data);
+    expect(strFromU8(unzipped["b.geojson"])).toBe(files[1].data);
+  });
+
+  it("accepts Uint8Array entries (the geoarrow-wasm writeGeoJSON output type)", () => {
+    // Construct bytes manually — TextEncoder isn't reliably available in jsdom.
+    const payload = Uint8Array.from([0x7b, 0x22, 0x6b, 0x22, 0x3a, 0x22, 0x76, 0x22, 0x7d]); // {"k":"v"}
+    const zipped = buildZip([{ name: "x.geojson", data: payload }]);
+
+    const unzipped = unzipSync(zipped);
+    expect(unzipped["x.geojson"]).toEqual(payload);
+  });
+
+  it("STORE mode (compress=false) produces output at least as large as the input payload", () => {
+    // STORE = no compression. The ZIP wrapper adds headers, so output > input.
+    // This is a sanity check that compress=false actually disables DEFLATE.
+    const payload = "x".repeat(1000);
+    const zipped = buildZip([{ name: "f.txt", data: payload }], { compress: false });
+    expect(zipped.length).toBeGreaterThanOrEqual(payload.length);
+  });
+
+  it("default (compress) shrinks highly compressible payloads", () => {
+    const payload = "x".repeat(5000); // trivially compressible
+    const stored = buildZip([{ name: "f.txt", data: payload }], { compress: false });
+    const deflated = buildZip([{ name: "f.txt", data: payload }]);
+    expect(deflated.length).toBeLessThan(stored.length);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty array", []],
+    ["non-array", "not an array"],
+  ])("throws TypeError when files is %s", (_label, input) => {
+    expect(() => buildZip(input)).toThrow(TypeError);
+  });
+
+  it("throws when a file is missing a name", () => {
+    expect(() => buildZip([{ data: "x" }])).toThrow(TypeError);
+  });
+
+  it("throws when a file has an empty name", () => {
+    expect(() => buildZip([{ name: "", data: "x" }])).toThrow(TypeError);
+  });
+
+  it("throws when a file is missing data", () => {
+    expect(() => buildZip([{ name: "a.txt" }])).toThrow(/missing.*data/);
+  });
+});
+
+describe("triggerBrowserDownload", () => {
+  let createObjectURLSpy;
+  let revokeObjectURLSpy;
+  let originalCreate;
+  let originalRevoke;
+
+  beforeEach(() => {
+    // jsdom doesn't implement URL.createObjectURL/revokeObjectURL, so we
+    // assign stubs directly rather than using jest.spyOn.
+    originalCreate = URL.createObjectURL;
+    originalRevoke = URL.revokeObjectURL;
+    createObjectURLSpy = jest.fn().mockReturnValue("blob:mock-url");
+    revokeObjectURLSpy = jest.fn();
+    URL.createObjectURL = createObjectURLSpy;
+    URL.revokeObjectURL = revokeObjectURLSpy;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+  });
+
+  it("creates an <a> with the correct href and download, clicks it, and cleans up", () => {
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // ZIP magic
+    const clickSpy = jest.fn();
+
+    // Spy on createElement to intercept the anchor element
+    const realCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = realCreate(tag);
+      if (tag === "a") el.click = clickSpy;
+      return el;
+    });
+
+    triggerBrowserDownload(bytes, "archive.zip");
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    const blob = createObjectURLSpy.mock.calls[0][0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/zip");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    // The anchor must be removed from the DOM after click
+    expect(document.querySelectorAll("a[download]").length).toBe(0);
+
+    // revokeObjectURL is deferred to next tick — verify it fires
+    jest.runAllTimers();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("passes a Blob through without re-wrapping", () => {
+    const blob = new Blob(["hello"], { type: "text/plain" });
+    triggerBrowserDownload(blob, "hello.txt");
+
+    expect(createObjectURLSpy).toHaveBeenCalledWith(blob);
+  });
+
+  it("respects a custom mimeType", () => {
+    triggerBrowserDownload(new Uint8Array([1, 2, 3]), "f.bin", {
+      mimeType: "application/octet-stream",
+    });
+
+    const blob = createObjectURLSpy.mock.calls[0][0];
+    expect(blob.type).toBe("application/octet-stream");
+  });
+
+  it("revokes the object URL even if click() throws", () => {
+    const realCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = realCreate(tag);
+      if (tag === "a") {
+        el.click = () => {
+          throw new Error("simulated click failure");
+        };
+      }
+      return el;
+    });
+
+    expect(() =>
+      triggerBrowserDownload(new Uint8Array([1]), "f.zip")
+    ).toThrow("simulated click failure");
+
+    // Anchor must still be removed despite the throw
+    expect(document.querySelectorAll("a[download]").length).toBe(0);
+
+    jest.runAllTimers();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:mock-url");
+  });
+});
+
+describe("downloadAsZip", () => {
+  let originalCreate;
+  let originalRevoke;
+  let createObjectURLSpy;
+
+  beforeEach(() => {
+    originalCreate = URL.createObjectURL;
+    originalRevoke = URL.revokeObjectURL;
+    createObjectURLSpy = jest.fn().mockReturnValue("blob:mock-url");
+    URL.createObjectURL = createObjectURLSpy;
+    URL.revokeObjectURL = jest.fn();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+  });
+
+  it("builds a valid ZIP and triggers a download with the given archive name", () => {
+    const clickSpy = jest.fn();
+    const realCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = realCreate(tag);
+      if (tag === "a") el.click = clickSpy;
+      return el;
+    });
+
+    const files = [
+      { name: "buildings.geojson", data: '{"type":"FeatureCollection"}' },
+      { name: "places.geojson", data: '{"type":"FeatureCollection"}' },
+    ];
+
+    downloadAsZip(files, "overture-bundle.zip");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    // Verify the blob handed to createObjectURL is a real ZIP we can read back
+    const blob = createObjectURLSpy.mock.calls[0][0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/zip");
+  });
+
+  it("propagates buildZip validation errors without invoking the DOM", () => {
+    const createElementSpy = jest.spyOn(document, "createElement");
+    expect(() => downloadAsZip([], "empty.zip")).toThrow(TypeError);
+    expect(createElementSpy).not.toHaveBeenCalled();
+  });
+});

--- a/components/nav/DownloadButton.jsx
+++ b/components/nav/DownloadButton.jsx
@@ -13,6 +13,7 @@ import IconButton from "@mui/material/IconButton";
 import initWasm from "@geoarrow/geoarrow-wasm/esm/index.js";
 import { getVisibleTypes } from "@/lib/LayerManager";
 import { downloadAsZip } from "@/lib/zipDownload";
+import { buildDownloadMetadata } from "@/lib/downloadMetadata";
 
 const ZOOM_BOUND = 15;
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
@@ -105,17 +106,32 @@ function DownloadButton({ mode, zoom, setZoom, visibleTypes}) {
         // Collect each non-empty layer as a GeoJSON file inside a single ZIP.
         // Bundling avoids iOS Safari silently dropping multi-file downloads
         // and Chrome's "allow multiple downloads" prompt — see issue #190.
-        const files = wasmTables
-          .filter((wasmTable) => wasmTable?.reader?.numBatches > 0)
-          .map((wasmTable) => ({
-            name: `overture-${releaseVersion}-${wasmTable.type}-${bboxStr}.geojson`,
-            data: writeGeoJSON(wasmTable.reader),
-          }));
+        const nonEmptyTables = wasmTables.filter(
+          (wasmTable) => wasmTable?.reader?.numBatches > 0
+        );
+
+        const files = nonEmptyTables.map((wasmTable) => ({
+          name: `overture-${releaseVersion}-${wasmTable.type}-${bboxStr}.geojson`,
+          data: writeGeoJSON(wasmTable.reader),
+        }));
 
         if (files.length === 0) {
           console.warn("No non-empty layers in the current view");
           return;
         }
+
+        // Include a metadata.json describing the bbox, release, and current
+        // map view URL so the download is self-describing and reproducible
+        // via overturemaps-py / DuckDB. See issue #156.
+        files.push({
+          name: "metadata.json",
+          data: buildDownloadMetadata({
+            bbox,
+            releaseVersion,
+            layers: nonEmptyTables.map((t) => t.type),
+            viewUrl: typeof window !== "undefined" ? window.location.href : undefined,
+          }),
+        });
 
         const archiveName = `overture-${releaseVersion}-${bboxStr}.zip`;
         downloadAsZip(files, archiveName);

--- a/components/nav/DownloadButton.jsx
+++ b/components/nav/DownloadButton.jsx
@@ -12,6 +12,7 @@ import Tooltip from "@mui/material/Tooltip";
 import IconButton from "@mui/material/IconButton";
 import initWasm from "@geoarrow/geoarrow-wasm/esm/index.js";
 import { getVisibleTypes } from "@/lib/LayerManager";
+import { downloadAsZip } from "@/lib/zipDownload";
 
 const ZOOM_BOUND = 15;
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
@@ -88,46 +89,41 @@ function DownloadButton({ mode, zoom, setZoom, visibleTypes}) {
         );
       });
 
-      await Promise.all(datasets)
-        .then((datasets) => {
-          return datasets.map((dataset) =>
-            dataset.parquet.read(readOptions).then((reader) => {
-              return { type: dataset.type, reader: reader };
-            })
-          );
-        })
-        .then((tableReads) =>
-          Promise.all(tableReads)
-            .then((wasmTables) => {
-              wasmTables.map((wasmTable) => {
-                if (wasmTable?.reader?.numBatches > 0) {
-                  const binaryDataForDownload = writeGeoJSON(wasmTable.reader);
+      try {
+        const resolvedDatasets = await Promise.all(datasets);
+        const wasmTables = await Promise.all(
+          resolvedDatasets.map((dataset) =>
+            dataset.parquet.read(readOptions).then((reader) => ({
+              type: dataset.type,
+              reader,
+            }))
+          )
+        );
 
-                  let blerb = new Blob([binaryDataForDownload], {
-                    type: "application/octet-stream",
-                  });
+        const bboxStr = bbox.map((v) => v.toFixed(3)).join(",");
 
-                  const url = URL.createObjectURL(blerb);
-                  var downloadLink = document.createElement("a");
-                  downloadLink.href = url;
+        // Collect each non-empty layer as a GeoJSON file inside a single ZIP.
+        // Bundling avoids iOS Safari silently dropping multi-file downloads
+        // and Chrome's "allow multiple downloads" prompt — see issue #190.
+        const files = wasmTables
+          .filter((wasmTable) => wasmTable?.reader?.numBatches > 0)
+          .map((wasmTable) => ({
+            name: `overture-${releaseVersion}-${wasmTable.type}-${bboxStr}.geojson`,
+            data: writeGeoJSON(wasmTable.reader),
+          }));
 
-                  const bboxStr = bbox.map((v) => v.toFixed(3)).join(",");
-                  downloadLink.download = `overture-${releaseVersion}-${wasmTable.type}-${bboxStr}.geojson`;
+        if (files.length === 0) {
+          console.warn("No non-empty layers in the current view");
+          return;
+        }
 
-                  document.body.appendChild(downloadLink);
-                  downloadLink.click();
-                  document.body.removeChild(downloadLink);
-                }
-              });
-            })
-            .then(() => {
-              setLoading(false);
-            })
-        ).catch(error => {
-          // Something went wrong with the download.
-          console.error("An error occurred during the download:", error);
-          alert("An error occurred during the download. Please try again.");
-        });
+        const archiveName = `overture-${releaseVersion}-${bboxStr}.zip`;
+        downloadAsZip(files, archiveName);
+      } catch (error) {
+        // Something went wrong with the download.
+        console.error("An error occurred during the download:", error);
+        alert("An error occurred during the download. Please try again.");
+      }
     } catch (error) {
       console.error("Error in download process:", error);
       alert("An error occurred while preparing the download. Please try again.");

--- a/lib/downloadMetadata.js
+++ b/lib/downloadMetadata.js
@@ -1,0 +1,60 @@
+/**
+ * Builds the metadata.json contents that ship inside every download ZIP.
+ *
+ * This file gives the user everything they need to:
+ *   - Re-run the same query against parquet via overturemaps-py / DuckDB
+ *     (the `bboxString` field is in the exact format both tools accept)
+ *   - Reopen the same view in Explore (the `viewUrl` includes the map hash)
+ *   - Trace the data back to a specific Overture release
+ *
+ * Kept as a pure function so it can be unit-tested without spinning up a
+ * MapLibre instance. See issue #156.
+ */
+
+/**
+ * @param {object} params
+ * @param {[number, number, number, number]} params.bbox - [west, south, east, north]
+ * @param {string} params.releaseVersion - Overture release id, e.g. "2024-09-18"
+ * @param {string[]} params.layers - the layer type names included in this download
+ * @param {string} [params.viewUrl] - full URL with map hash, e.g. window.location.href
+ * @param {Date} [params.now] - injected for deterministic tests; defaults to new Date()
+ * @returns {string} pretty-printed JSON suitable for a metadata.json file
+ */
+export function buildDownloadMetadata({
+  bbox,
+  releaseVersion,
+  layers,
+  viewUrl,
+  now = new Date(),
+}) {
+  if (!Array.isArray(bbox) || bbox.length !== 4 || !bbox.every(Number.isFinite)) {
+    throw new TypeError(
+      "bbox must be an array of 4 finite numbers [west, south, east, north]"
+    );
+  }
+  if (typeof releaseVersion !== "string" || releaseVersion.length === 0) {
+    throw new TypeError("releaseVersion must be a non-empty string");
+  }
+  if (!Array.isArray(layers)) {
+    throw new TypeError("layers must be an array");
+  }
+
+  const [west, south, east, north] = bbox;
+
+  const metadata = {
+    source: "https://explore.overturemaps.org/",
+    // overturemaps-py and DuckDB ST_MakeEnvelope both accept this exact format
+    bboxString: `${west},${south},${east},${north}`,
+    bbox: { west, south, east, north },
+    release: releaseVersion,
+    layers: [...layers].sort(),
+    generatedAt: now.toISOString(),
+  };
+
+  // viewUrl is optional — server-side rendering or tests may not have a window
+  if (typeof viewUrl === "string" && viewUrl.length > 0) {
+    metadata.viewUrl = viewUrl;
+  }
+
+  return JSON.stringify(metadata, null, 2);
+}

--- a/lib/zipDownload.js
+++ b/lib/zipDownload.js
@@ -22,10 +22,16 @@
 
 import { zipSync, strToU8 } from "fflate";
 
+// Filenames that would either pollute Object.prototype on a plain-object map
+// or trip fflate's internal input handling (which can't accept a "__proto__"
+// key even on a null-prototype object). These names are never legitimate
+// filenames inside a ZIP we generate, so rejecting them up-front is safe.
+const FORBIDDEN_FILENAMES = new Set(["__proto__", "prototype", "constructor"]);
+
 /**
  * Build a ZIP archive from an array of {name, data} entries.
  *
- * @param {Array<{name: string, data: Uint8Array | string}>} files
+ * @param {Array<{name: string, data: Uint8Array | ArrayBuffer | string}>} files
  * @param {{compress?: boolean}} [options] - compress=false switches to STORE (no compression). Defaults to true (DEFLATE level 6).
  * @returns {Uint8Array} the raw ZIP bytes
  * @throws {TypeError} if files is not a non-empty array of valid entries
@@ -36,18 +42,35 @@ export function buildZip(files, options = {}) {
   }
 
   const level = options.compress === false ? 0 : 6;
-  const zipInput = {};
+  // Object.create(null) so caller-supplied filenames like "__proto__" or
+  // "constructor" become safe keys instead of mutating Object.prototype.
+  const zipInput = Object.create(null);
 
   for (const file of files) {
     if (!file || typeof file.name !== "string" || file.name.length === 0) {
       throw new TypeError("each file must have a non-empty string `name`");
     }
+    if (FORBIDDEN_FILENAMES.has(file.name)) {
+      throw new TypeError(
+        `file name "${file.name}" is reserved and cannot be used`
+      );
+    }
     if (file.data == null) {
       throw new TypeError(`file "${file.name}" is missing \`data\``);
     }
 
-    const bytes =
-      typeof file.data === "string" ? strToU8(file.data) : file.data;
+    let bytes;
+    if (typeof file.data === "string") {
+      bytes = strToU8(file.data);
+    } else if (file.data instanceof Uint8Array) {
+      bytes = file.data;
+    } else if (file.data instanceof ArrayBuffer) {
+      bytes = new Uint8Array(file.data);
+    } else {
+      throw new TypeError(
+        `file "${file.name}" must have \`data\` as a string, Uint8Array, or ArrayBuffer`
+      );
+    }
 
     // fflate per-entry options: level 0 = STORE, 6 = DEFLATE default.
     zipInput[file.name] = [bytes, { level }];

--- a/lib/zipDownload.js
+++ b/lib/zipDownload.js
@@ -1,0 +1,99 @@
+/**
+ * Helpers for packaging multiple in-memory files into a single ZIP archive
+ * and triggering a browser download.
+ *
+ * Why ZIP everything into one file?
+ *   Mobile Safari (iOS) silently drops all but the first programmatic
+ *   download per user gesture, and even desktop browsers prompt the user to
+ *   "allow multiple downloads" when an `<a download>` is clicked more than
+ *   once in quick succession. Returning a single archive sidesteps both.
+ *
+ * fflate is used in DEFLATE mode (level 6) by default. GeoJSON is highly
+ * repetitive (`"type"`, `"properties"`, `"geometry"`, `"coordinates"` on every
+ * feature) and typically compresses 5-10x. The CPU cost is negligible vs. the
+ * parquet-to-GeoJSON WASM step that already gates the download. Pass
+ * `compress: false` to fall back to STORE mode if a benchmark ever shows the
+ * tradeoff has flipped.
+ *
+ * The helpers are split so the pure packaging logic (`buildZip`) is trivially
+ * testable in jsdom without touching the DOM, while `triggerBrowserDownload`
+ * isolates the side-effecting bits.
+ */
+
+import { zipSync, strToU8 } from "fflate";
+
+/**
+ * Build a ZIP archive from an array of {name, data} entries.
+ *
+ * @param {Array<{name: string, data: Uint8Array | string}>} files
+ * @param {{compress?: boolean}} [options] - compress=false switches to STORE (no compression). Defaults to true (DEFLATE level 6).
+ * @returns {Uint8Array} the raw ZIP bytes
+ * @throws {TypeError} if files is not a non-empty array of valid entries
+ */
+export function buildZip(files, options = {}) {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new TypeError("buildZip requires a non-empty array of files");
+  }
+
+  const level = options.compress === false ? 0 : 6;
+  const zipInput = {};
+
+  for (const file of files) {
+    if (!file || typeof file.name !== "string" || file.name.length === 0) {
+      throw new TypeError("each file must have a non-empty string `name`");
+    }
+    if (file.data == null) {
+      throw new TypeError(`file "${file.name}" is missing \`data\``);
+    }
+
+    const bytes =
+      typeof file.data === "string" ? strToU8(file.data) : file.data;
+
+    // fflate per-entry options: level 0 = STORE, 6 = DEFLATE default.
+    zipInput[file.name] = [bytes, { level }];
+  }
+
+  return zipSync(zipInput);
+}
+
+/**
+ * Trigger a browser download of the given bytes as a single file.
+ * Safe to call from any user-gesture-initiated handler.
+ *
+ * @param {Uint8Array | Blob} data
+ * @param {string} filename
+ * @param {{mimeType?: string, doc?: Document}} [options]
+ *   `doc` is injected for testability; defaults to global document.
+ */
+export function triggerBrowserDownload(data, filename, options = {}) {
+  const { mimeType = "application/zip", doc = document } = options;
+
+  const blob = data instanceof Blob ? data : new Blob([data], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  const link = doc.createElement("a");
+  link.href = url;
+  link.download = filename;
+
+  doc.body.appendChild(link);
+  try {
+    link.click();
+  } finally {
+    doc.body.removeChild(link);
+    // Revoke on the next tick so the browser has a chance to start the download
+    // before the URL is invalidated.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+}
+
+/**
+ * Convenience: build a ZIP and immediately trigger its download.
+ *
+ * @param {Array<{name: string, data: Uint8Array | string}>} files
+ * @param {string} archiveName
+ * @param {{compress?: boolean, doc?: Document}} [options]
+ */
+export function downloadAsZip(files, archiveName, options = {}) {
+  const bytes = buildZip(files, { compress: options.compress });
+  triggerBrowserDownload(bytes, archiveName, { doc: options.doc });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "explore-site",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -20,6 +21,7 @@
         "@mui/material": "^5.15.20",
         "@mui/x-tree-view": "^8.27.2",
         "apache-arrow": "^15.0.2",
+        "fflate": "^0.8.2",
         "iconoir-react": "^7.11.0",
         "maplibre-gl": "^5.18.0",
         "next": "^14.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@mui/material": "^5.15.20",
     "@mui/x-tree-view": "^8.27.2",
     "apache-arrow": "^15.0.2",
+    "fflate": "^0.8.2",
     "iconoir-react": "^7.11.0",
     "maplibre-gl": "^5.18.0",
     "next": "^14.2.0",


### PR DESCRIPTION
## Changes

### Archive Download

In order to avoid issues with browser conditions (i.e. iOS Safari not allowing multiple file downloads per single user interaction), default to zipping (and compressing) when a user clicks the Download button. This fixes #190 

This will reduce the download size (spot checking, 17mb vs 7mb for uncompressed vs compressed) and ensure a uniform experience regardless of platform/browser choice.

The approximate shape of this archive will be:

```text
    Directory: C:\Users\johnh\Downloads\overture-2026-04-15.0--78.402,11.505,-78.381,11.513


Length   Name
------   ----
548      metadata.json
16771251 overture-2026-04-15.0-bathymetry--78.402,11.505,-78.381,11.513.geojson
1180     overture-2026-04-15.0-infrastructure--78.402,11.505,-78.381,11.513.geojson
956278   overture-2026-04-15.0-land_cover--78.402,11.505,-78.381,11.513.geojson
1269     overture-2026-04-15.0-land_use--78.402,11.505,-78.381,11.513.geojson
589      overture-2026-04-15.0-water--78.402,11.505,-78.381,11.513.geojson
```

### Metadata.json

Also included in the archive will be metadata.json (resolves #156), increasing the ability to easily use the downloaded data in other tools.

```json
{
  "source": "https://explore.overturemaps.org/",
  "bboxString": "-78.4022398759016,11.505113709799872,-78.38111104410035,11.513050241704875",
  "bbox": {
    "west": -78.4022398759016,
    "south": 11.505113709799872,
    "east": -78.38111104410035,
    "north": 11.513050241704875
  },
  "release": "2026-04-15.0",
  "layers": [
    "bathymetry",
    "infrastructure",
    "land_cover",
    "land_use",
    "water"
  ],
  "generatedAt": "2026-04-30T21:27:04.132Z",
  "viewUrl": "http://localhost:3000/?mode=explore#16.17/11.509082/-78.391675"
}
```

