### PR TITLE
[CHORE](deps) Configure dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,22 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
+
+  # Maintain npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    labels:
+      - "bot"
+    commit-message:
+      prefix: "[CHORE](deps)"
+      include: "scope"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds an `npm` entry to `.github/dependabot.yml` alongside the existing `github-actions` block, so root `package.json` dependencies get automated update PRs.

Matches the `github-actions` block's conventions: weekly schedule, `bot` label, `[CHORE](deps)` commit prefix with scope, and a 7-day cooldown. Minor and patch updates are grouped into a single `npm-minor-patch` PR to cut down on noise; major bumps still open individually since those are more likely to need review.

Closes #337