### PR TITLE
[CHORE](deps) Group @mui packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # @mui/material, @mui/base, @mui/icons-material, and @mui/x-tree-view
+      # are peer-linked, so a major bump on one alone breaks resolution
+      # (see #341). Group them so dependabot proposes major bumps as one
+      # coordinated PR instead of piecemeal ones.
+      mui:
+        patterns:
+          - "@mui/*"
       npm-minor-patch:
         update-types:
           - "minor"


### PR DESCRIPTION
`@mui/material`, `@mui/base`, `@mui/icons-material`, and `@mui/x-tree-view` are peer-linked, so a major bump on one alone breaks resolution. That's what happened in #341: dependabot bumped `@mui/icons-material` alone to 9.2.0, which requires peer `@mui/material@^9.2.0`, but this repo is pinned to `@mui/material@^5.15.20` and `@mui/x-tree-view@8.27.2` doesn't support material v9 either. `npm ci` failed with `ERESOLVE` before anything built. Closed that PR since it can't merge standalone.

Adds a `mui` group so dependabot bundles all `@mui/*` updates, majors included, into one coordinated PR instead of proposing them piecemeal.