### PR TITLE
[BUG] Speed up initial map load

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -41,6 +41,8 @@ export default function RootLayout({ children }) {
         <style dangerouslySetInnerHTML={{ __html: fontFaceCSS }} />
         <link rel="preconnect" href="https://stac.overturemaps.org" />
         <link rel="preload" href="https://stac.overturemaps.org/catalog.json" as="fetch" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=bug_report,docs,download_for_offline,find_replace,frame_inspect,globe_asia,my_location,zoom_in,zoom_out&display=swap"

--- a/components/MapView.jsx
+++ b/components/MapView.jsx
@@ -13,6 +13,7 @@ import fontsJson from "@/components/map/tokens/primitive/fonts.json";
 import {
   addSources,
   addAllLayers,
+  preloadIcons,
   updateLayerVisibility,
   highlightFeature,
   getInteractiveLayerIds,
@@ -31,6 +32,11 @@ try {
 
 // Load PMTiles URLs from STAC catalog at module load time
 const pmtilesPromise = loadPmtilesFromStac();
+
+// Preload layer icon SVGs at module load time, in parallel with the STAC
+// fetch, map init, and font loading, so they're ready (or nearly ready)
+// by the time addAllLayers runs instead of only starting then.
+const iconsPromise = preloadIcons();
 
 // All font family names used by the map (must match @font-face declarations in globals.css)
 const fontNames = Object.values(fontsJson).flatMap((variants) =>
@@ -330,7 +336,7 @@ export default function Map({
 
     const map = mapRef.current;
     addSources(map, pmtilesUrls);
-    addAllLayers(map, visibleTypes).then(() => setSourcesAdded(true));
+    addAllLayers(map, visibleTypes, iconsPromise).then(() => setSourcesAdded(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapLoaded, fontsLoaded, pmtilesUrls]);
 

--- a/lib/LayerManager.js
+++ b/lib/LayerManager.js
@@ -157,30 +157,48 @@ export function addSources(map, pmtilesUrls) {
   }
 }
 
+const ICON_NAMES = ["star", "park", "airport", "beer", "grocery", "doctor", "fuel", "golf", "convenience", "lodging", "parking", "rail", "restaurant", "shop", "ranger-station", "stadium", "circle", "circle-stroked", "circle-opt"];
+
+/**
+ * Fetch all layer icon SVGs from disk. Doesn't touch the map, so it can be
+ * kicked off as soon as the app boots, in parallel with map init, STAC
+ * fetches, and font loading, instead of only starting once those are done.
+ * Returns a map of icon name → loaded Image (or null if it failed to load).
+ */
+export function preloadIcons() {
+  if (typeof Image === "undefined") {
+    // Server-side render / static generation — no browser Image constructor.
+    // addAllLayers only ever runs client-side, so an empty map is fine here.
+    return Promise.resolve(new Map());
+  }
+  return Promise.all(
+    ICON_NAMES.map(
+      (name) =>
+        new Promise((resolve) => {
+          const img = new Image(25, 25);
+          img.onload = () => resolve([name, img]);
+          img.onerror = () => resolve([name, null]);
+          img.src = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/icons/${name}.svg`;
+        })
+    )
+  ).then((entries) => new Map(entries));
+}
+
 /**
  * Add all default layers in the order defined by the layer list.
- * Also loads any required icon images.
+ * Also registers any required icon images with the map.
+ *
+ * iconsPromise: optional, from preloadIcons() — pass one started earlier
+ * (e.g. at module load) to avoid re-fetching icons that are already in
+ * flight or cached. Falls back to starting a fresh preload if omitted.
  */
-export async function addAllLayers(map, visibleItems) {
-  // Load icons from SVGs — wait for all to load before adding layers
-  const iconNames = ["star", "park", "airport", "beer", "grocery", "doctor", "fuel", "golf", "convenience", "lodging", "parking", "rail", "restaurant", "shop", "ranger-station", "stadium", "circle", "circle-stroked", "circle-opt"];
-
-  await Promise.all(
-    iconNames.map((name) => {
-      if (map.hasImage(name)) return Promise.resolve();
-      return new Promise((resolve) => {
-        const img = new Image(25, 25);
-        img.onload = () => {
-          if (!map.hasImage(name)) {
-            map.addImage(name, img);
-          }
-          resolve();
-        };
-        img.onerror = resolve;
-        img.src = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/icons/${name}.svg`;
-      });
-    })
-  );
+export async function addAllLayers(map, visibleItems, iconsPromise) {
+  const icons = await (iconsPromise || preloadIcons());
+  for (const [name, img] of icons) {
+    if (img && !map.hasImage(name)) {
+      map.addImage(name, img);
+    }
+  }
 
   for (const spec of defaultLayerSpecs) {
     const styled = applyRuntimeStyle(spec, visibleItems);


### PR DESCRIPTION
Chrome DevTools flagged a PBO readback warning during runtime, which traced to maplibre-gl's globe-projection error correction (upstream, benign). The real complaint was slow initial load, which comes from three serial gates before `addAllLayers` can paint anything: map `"load"`, 17 font-family loads, and the STAC PMTiles fetch. On top of that, `addAllLayers` itself fired 19 icon `Image()` requests only after all three gates cleared, adding another serial round trip.

- `app/layout.jsx`: add preconnect hints for `fonts.googleapis.com` and `fonts.gstatic.com` (`crossOrigin` for the gstatic one, since font files fetch with CORS), matching the existing STAC preconnect. Without these, the two Google Fonts stylesheets pay a cold DNS+TLS handshake on every fresh visit.
- `lib/LayerManager.js`: extract icon loading into `preloadIcons()`, started at module load time (mirrors the existing `pmtilesPromise` pattern) instead of inside `addAllLayers`. Icons are static local SVGs with no dependency on map state, so there's no reason to wait for the other three gates before fetching them. Guards for SSR/static generation since `Image` doesn't exist server-side.
- `components/MapView.jsx`: kick off `iconsPromise` alongside `pmtilesPromise` and thread it into `addAllLayers`.

I checked whether the `fontsLoaded` gate could be relaxed to a subset of the 17 font-family names, but all 17 map to just 3 underlying `.woff2` files, so `Promise.all` is already bounded by 3 parallel downloads. Left it alone.

## Testing

- `npm run lint`, `npm run test:ci` (649 tests), and `npm run build` all pass.
- Not measured against a live network trace; the icon and font-preconnect changes overlap previously-serial work with the STAC/map-init fetches, so the expected win is proportional to icon fetch + Google Fonts handshake time, not verified with a before/after Lighthouse run.