### PR TITLE
[BUG] fix broken map loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 out
 .swc
 public/mapbox-gl-rtl-text.js
+public/maplibre

--- a/components/MapView.jsx
+++ b/components/MapView.jsx
@@ -21,6 +21,8 @@ import {
   updateInspectVisibility,
 } from "@/lib/LayerManager";
 
+maplibregl.setWorkerUrl('/maplibre/maplibre-gl-worker.mjs');
+
 // Set RTL text plugin for Arabic/Hebrew rendering (must be called once, before map init)
 try {
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test": "jest",
     "test:ci": "jest --ci --passWithNoTests",
     "test:a11y": "node --test --test-reporter=spec __tests__/a11y.test.mjs",
+    "prebuild": "node ./scripts/copy-maplibre-worker.mjs",
+    "predev": "node ./scripts/copy-maplibre-worker.mjs",
     "preview": "npx serve out"
   },
   "dependencies": {


### PR DESCRIPTION
* maplibre GL JS v6 requires explicit configuration of the web worker: https://maplibre.org/maplibre-gl-js/docs/#esm

Fixes #362
Fixes #363